### PR TITLE
Fix assembly load time

### DIFF
--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/GameCenter/RangeTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/GameCenter/RangeTests.cs
@@ -3,6 +3,7 @@ using UnityEngine.SocialPlatforms;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.GameCenter
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public class RangeTests : ValueTypeTester<Range>
     {
         public static readonly IReadOnlyCollection<(Range deserialized, object anonymous)> representations = new (Range, object)[] {
@@ -10,4 +11,5 @@ namespace Newtonsoft.Json.UnityConverters.Tests.GameCenter
             (new Range(1, 2), new { from = 1, count = 2 }),
         };
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Graphics/ResolutionTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Graphics/ResolutionTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-namespace Newtonsoft.Json.UnityConverters.Tests.Math
+namespace Newtonsoft.Json.UnityConverters.Tests.Graphics
 {
     public class ResolutionTests : ValueTypeTester<Resolution>
     {
@@ -10,15 +10,33 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Math
                 width = 0,
                 height = 0,
                 refreshRate = 0,
+#if UNITY_2022_2_OR_NEWER
+                // For 2022.2+, we want it to print both refreshRate and refreshRateRatio, to not break backward compatibility.
+                refreshRateRatio = new {
+                    numerator = 0,
+                    denominator = 0,
+                    value = double.NaN,
+                },
+#endif
             }),
             (new Resolution {
                 width = 1,
                 height = 2,
+#pragma warning disable CS0618 // Type or member is obsolete
                 refreshRate = 3,
+#pragma warning restore CS0618 // Type or member is obsolete
             }, new {
                 width = 1,
                 height = 2,
                 refreshRate = 3,
+#if UNITY_2022_2_OR_NEWER
+                // For 2022.2+, we want it to print both refreshRate and refreshRateRatio, to not break backward compatibility.
+                refreshRateRatio = new {
+                    numerator = 3,
+                    denominator = 1,
+                    value = 3.0d,
+                },
+#endif
             }),
         };
     }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Math/GradientTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Math/GradientTests.cs
@@ -16,7 +16,10 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Math
                     new { alpha = 1f, time = 0f },
                     new { alpha = 1f, time = 1f },
                 },
-                mode = GradientMode.Blend
+                mode = GradientMode.Blend,
+#if UNITY_2022_2_OR_NEWER
+                colorSpace = ColorSpace.Uninitialized,
+#endif
             }),
             (new Gradient{
                 colorKeys = new[] {
@@ -36,7 +39,10 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Math
                     new GradientAlphaKey(1, .6f),
                     new GradientAlphaKey(3, .8f),
                 },
-                mode = GradientMode.Blend
+                mode = GradientMode.Blend,
+#if UNITY_2022_2_OR_NEWER
+                colorSpace = ColorSpace.Linear,
+#endif
             }, new {
                 colorKeys = new[] {
                     new { color = new { r = 5f, g = 6f, b = 7f, a = 1f }, time = .2f },
@@ -46,7 +52,10 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Math
                     new { alpha = 1f, time = .6f },
                     new { alpha = 3f, time = .8f },
                 },
-                mode = GradientMode.Blend
+                mode = GradientMode.Blend,
+#if UNITY_2022_2_OR_NEWER
+                colorSpace = ColorSpace.Linear,
+#endif
             }),
         };
 
@@ -54,7 +63,11 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Math
         {
             return a.alphaKeys.SequenceEqual(b.alphaKeys)
                 && a.colorKeys.SequenceEqual(b.colorKeys)
-                && a.mode == b.mode;
+                && a.mode == b.mode
+#if UNITY_2022_2_OR_NEWER
+                && a.colorSpace == b.colorSpace
+#endif
+                ;
         }
     }
 

--- a/Assets/Resources/Newtonsoft.Json-for-Unity.Converters.asset
+++ b/Assets/Resources/Newtonsoft.Json-for-Unity.Converters.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ce56e4dbb13e1644aa983b6dd170e4a7, type: 3}
   m_Name: Newtonsoft.Json-for-Unity.Converters
-  m_EditorClassIdentifier:
+  m_EditorClassIdentifier: 
   useUnityContractResolver: 1
   useAllOutsideConverters: 1
   outsideConverters: []
@@ -46,6 +46,9 @@ MonoBehaviour:
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.RectOffsetConverter
+    settings: []
+  - enabled: 1
+    converterName: Newtonsoft.Json.UnityConverters.Graphics.ResolutionConverter
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Hashing.Hash128Converter
@@ -154,3 +157,4 @@ MonoBehaviour:
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.XmlNodeConverter
     settings: []
+  autoSyncConverters: 1

--- a/Build/version.json
+++ b/Build/version.json
@@ -1,7 +1,7 @@
 {
   "Major": 1,
-  "Minor": 5,
-  "Patch": 1,
+  "Minor": 6,
+  "Patch": 0,
   "Suffix": "",
-  "AutoDeployLiveRun": true
+  "AutoDeployLiveRun": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
 # Unity Converters for Newtonsoft.Json changelog
 
-## 1.5.2 (WIP)
+## 1.6.0 (WIP)
+
+- Added `ResolutionConverter` to be able to read JSON from older Unity
+  versions. ([#79](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/79))
+
+- Fixed compilation errors when targeting .NET Standard 2.1.
+  ([#79](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/79))
 
 - Fixed converter types taking long time to load, sometimes causing lag spikes
   each time assembly got reloaded (especially when entering play-mode).
 
-  Thanks [@Mefodei](https://github.com/Mefodei) for the implementation ([#78](https://github.com/applejag/Newtonsoft.Json-for-Unity.Converters/pull/78))
+  The issue was that this package tries to find all converters by looping
+  through all types in all assemblies.
+
+  You should see better performance now, as we are using more optimized code
+  paths and making use of Unity's [TypeCache](https://docs.unity3d.com/2023.3/Documentation/ScriptReference/TypeCache.html).
+
+  If your project still suffers from big lag spikes, then you can opt-out
+  completely of the "auto type scanning" code via the settings found at
+  "Edit > Json.NET converters settings..." ([#79](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/79))
+
+  - Thanks [@tomkail](https://github.com/tomkail) for the excellent issue ([#77](https://github.com/applejag/Newtonsoft.Json-for-Unity.Converters/issues/77)).
+  - Thanks [@Mefodei](https://github.com/Mefodei) for the inspiration ([#78](https://github.com/applejag/Newtonsoft.Json-for-Unity.Converters/pull/78))
 
 ## 1.5.1 (2023-04-19)
 

--- a/Doc/Compatability-table.md
+++ b/Doc/Compatability-table.md
@@ -27,7 +27,7 @@ https://beautifuldingbats.com/superscript-generator/
 | Geometry       | *UnityEngine*.**Rect**                                          | ✔               | ✔               | ✔                |
 | Geometry       | *UnityEngine*.**RectInt**                                       | ✔               | ✔               | ✔                |
 | Geometry       | *UnityEngine*.**RectOffset**                                    | ✔               | ✔               | ✔                |
-| Graphics       | *UnityEngine*.**Resolution**                                    | ✔               | ✔               | ✖[⁽¹⁾](#note-1)  |
+| Graphics       | *UnityEngine*.**Resolution**                                    | ✔               | ✔               | ✔                |
 | Hashing        | *UnityEngine*.**Hash128**                                       | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Color**                                         | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Color32**                                       | ✔               | ✔               | ✔                |

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/ConverterConfig.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/ConverterConfig.cs
@@ -12,8 +12,6 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
 
         public string converterName;
 
-        public string converterType;
-
         public List<KeyedConfig> settings;
 
         public override string ToString()

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/UnityConvertersConfig.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/UnityConvertersConfig.cs
@@ -29,6 +29,8 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
             new ConverterConfig { converterName = typeof(StringEnumConverter).FullName, enabled = true },
             new ConverterConfig { converterName = typeof(VersionConverter).FullName, enabled = true },
         };
+
+        public bool autoSyncConverters = true;
     }
 #pragma warning restore CA2235 // Mark all non-serializable fields
 }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/UnityConvertersConfig.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/UnityConvertersConfig.cs
@@ -13,8 +13,6 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
         internal const string PATH = "Assets/Resources/Newtonsoft.Json-for-Unity.Converters.asset";
         internal const string PATH_FOR_RESOURCES_LOAD = "Newtonsoft.Json-for-Unity.Converters";
 
-        public bool useBakedConverters = true;
-
         public bool useUnityContractResolver = true;
 
         public bool useAllOutsideConverters = true;
@@ -31,7 +29,6 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
             new ConverterConfig { converterName = typeof(StringEnumConverter).FullName, enabled = true },
             new ConverterConfig { converterName = typeof(VersionConverter).FullName, enabled = true },
         };
-        
     }
 #pragma warning restore CA2235 // Mark all non-serializable fields
 }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Editor/UnityConvertersConfigEditor.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Editor/UnityConvertersConfigEditor.cs
@@ -63,7 +63,7 @@ namespace Newtonsoft.Json.UnityConverters.Editor
             _outsideConvertersShow.valueChanged.AddListener(Repaint);
             _unityConvertersShow.valueChanged.AddListener(Repaint);
             _jsonNetConvertersShow.valueChanged.AddListener(Repaint);
-            _headerStyle = new GUIStyle { fontSize = 20, wordWrap = true, normal = EditorStyles.label?.normal };
+            _headerStyle = new GUIStyle { fontSize = 20, wordWrap = true, normal = EditorStyles.label.normal };
             _boldHeaderStyle = new GUIStyle { fontSize = 20, fontStyle = FontStyle.Bold, wordWrap = true, normal = EditorStyles.label.normal };
 
             serializedObject.Update();

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Editor/UnityConvertersConfigEditor.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Editor/UnityConvertersConfigEditor.cs
@@ -23,13 +23,11 @@ namespace Newtonsoft.Json.UnityConverters.Editor
         private SerializedProperty _unityConverters;
         private SerializedProperty _useAllJsonNetConverters;
         private SerializedProperty _jsonNetConverters;
-        private SerializedProperty _useBakingConverters;
 
         private AnimBool _outsideConvertersShow;
         private AnimBool _unityConvertersShow;
         private AnimBool _jsonNetConvertersShow;
 
-        private UnityConvertersConfig _config;
         private GUIStyle _headerStyle;
         private GUIStyle _boldHeaderStyle;
 
@@ -52,7 +50,6 @@ namespace Newtonsoft.Json.UnityConverters.Editor
                 return;
             }
 
-            _config = serializedObject.targetObject as UnityConvertersConfig;
             _useUnityContractResolver = serializedObject.FindProperty(nameof(UnityConvertersConfig.useUnityContractResolver));
             _useAllOutsideConverters = serializedObject.FindProperty(nameof(UnityConvertersConfig.useAllOutsideConverters));
             _outsideConverters = serializedObject.FindProperty(nameof(UnityConvertersConfig.outsideConverters));
@@ -60,7 +57,6 @@ namespace Newtonsoft.Json.UnityConverters.Editor
             _unityConverters = serializedObject.FindProperty(nameof(UnityConvertersConfig.unityConverters));
             _useAllJsonNetConverters = serializedObject.FindProperty(nameof(UnityConvertersConfig.useAllJsonNetConverters));
             _jsonNetConverters = serializedObject.FindProperty(nameof(UnityConvertersConfig.jsonNetConverters));
-            _useBakingConverters = serializedObject.FindProperty(nameof(UnityConvertersConfig.useBakedConverters));
 
             _outsideConvertersShow = new AnimBool(_outsideConverters.isExpanded);
             _unityConvertersShow = new AnimBool(_unityConverters.isExpanded);
@@ -95,18 +91,6 @@ namespace Newtonsoft.Json.UnityConverters.Editor
                 " 'UnityEngine.ScriptableObject' via 'ScriptableObject.Create()' instead of the default" +
                 " 'new ScriptableObject()'.");
 
-            ToggleLeft(_useBakingConverters, "If true - use baked converters at runtime");
-            
-            EditorGUILayout.Separator();
-            EditorGUILayout.Space();
-
-            if (GUILayout.Button("Bake Json Converters"))
-            {
-                UnityConverterInitializer.BakeConverters(_config);
-                EditorUtility.SetDirty(_config);
-                AssetDatabase.SaveAssetIfDirty(_config);
-            }
-            
             EditorGUILayout.Space();
 
             FoldedConverters(_useAllOutsideConverters, _outsideConverters, _outsideConvertersShow,
@@ -144,7 +128,7 @@ namespace Newtonsoft.Json.UnityConverters.Editor
             var elementTypes = elements
                 .Select(e => TypeCache.FindType(e.FindPropertyRelative(nameof(ConverterConfig.converterName)).stringValue))
                 .ToArray();
-            
+
             Type[] missingConverters = converterTypes
                 .Where(type => !elementTypes.Contains(type))
                 .ToArray();
@@ -153,15 +137,13 @@ namespace Newtonsoft.Json.UnityConverters.Editor
             {
                 int nextIndex = arrayProperty.arraySize;
                 arrayProperty.InsertArrayElementAtIndex(nextIndex);
-                
+
                 SerializedProperty elemProp = arrayProperty.GetArrayElementAtIndex(nextIndex);
                 SerializedProperty enabledProp = elemProp.FindPropertyRelative(nameof(ConverterConfig.enabled));
                 SerializedProperty converterNameProp = elemProp.FindPropertyRelative(nameof(ConverterConfig.converterName));
-                SerializedProperty converterTypeProp = elemProp.FindPropertyRelative(nameof(ConverterConfig.converterType));
 
                 enabledProp.boolValue = newAreEnabledByDefault;
                 converterNameProp.stringValue = converterType.FullName;
-                converterTypeProp.stringValue = converterType.AssemblyQualifiedName;
             }
         }
 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/ConverterGrouping.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/ConverterGrouping.cs
@@ -1,0 +1,65 @@
+﻿#region License
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Wanzyee Studio
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+#if UNITY_EDITOR
+#endif
+
+namespace Newtonsoft.Json.UnityConverters
+{
+    internal class ConverterGrouping
+    {
+        public List<Type> outsideConverters { get; set; }
+        public List<Type> unityConverters { get; set; }
+        public List<Type> jsonNetConverters { get; set; }
+
+        public static ConverterGrouping Create(IEnumerable<Type> types)
+        {
+            var grouping = new ConverterGrouping {
+                outsideConverters = new List<Type>(),
+                unityConverters = new List<Type>(),
+                jsonNetConverters = new List<Type>(),
+            };
+
+            foreach (var converter in types)
+            {
+                if (converter.Namespace?.StartsWith("Newtonsoft.Json.UnityConverters") == true)
+                {
+                    grouping.unityConverters.Add(converter);
+                }
+                else if (converter.Namespace?.StartsWith("Newtonsoft.Json.Converters") == true)
+                {
+                    grouping.jsonNetConverters.Add(converter);
+                }
+                else
+                {
+                    grouping.outsideConverters.Add(converter);
+                }
+            }
+
+            return grouping;
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/ConverterGrouping.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/ConverterGrouping.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8df7670f2ef36e4d8a1222c390b28e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Graphics.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Graphics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83cc1315150ccd948ba38f1d831f7daa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Graphics/ResolutionConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Graphics/ResolutionConverter.cs
@@ -1,0 +1,61 @@
+﻿using Newtonsoft.Json.UnityConverters.Helpers;
+using UnityEngine;
+
+namespace Newtonsoft.Json.UnityConverters.Graphics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity Color type <see cref="Color"/>.
+    /// </summary>
+    public class ResolutionConverter : PartialConverter<Resolution>
+    {
+        protected override void ReadValue(ref Resolution value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.width):
+                    value.width = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.height):
+                    value.height = reader.ReadAsInt32() ?? 0;
+                    break;
+#pragma warning disable CS0618 // Type or member is obsolete
+                case nameof(value.refreshRate):
+                    value.refreshRate = reader.ReadAsInt32() ?? 0;
+                    break;
+#pragma warning restore CS0618 // Type or member is obsolete
+#if UNITY_2022_2_OR_NEWER
+                case nameof(value.refreshRateRatio):
+                    value.refreshRateRatio = reader.ReadViaSerializer<RefreshRate>(serializer);
+                    break;
+#endif
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, Resolution value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.width));
+            writer.WriteValue(value.width);
+            writer.WritePropertyName(nameof(value.height));
+            writer.WriteValue(value.height);
+#pragma warning disable CS0618 // Type or member is obsolete
+            writer.WritePropertyName(nameof(value.refreshRate));
+#if UNITY_2022_2_OR_NEWER
+            if (double.IsNaN(value.refreshRateRatio.value))
+            {
+                writer.WriteValue(0);
+            }
+            else
+            {
+                writer.WriteValue(value.refreshRate);
+            }
+#else
+            writer.WriteValue(value.refreshRate);
+#endif
+#pragma warning restore CS0618 // Type or member is obsolete
+#if UNITY_2022_2_OR_NEWER
+            writer.WritePropertyName(nameof(value.refreshRateRatio));
+            serializer.Serialize(writer, value.refreshRateRatio);
+#endif
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Graphics/ResolutionConverter.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Graphics/ResolutionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70e05895d45a929479175438ea0ccf75

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/NullableAttributes.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/NullableAttributes.cs
@@ -1,6 +1,6 @@
 ﻿#pragma warning disable MA0048 // File name must match type name
 #define INTERNAL_NULLABLE_ATTRIBUTES
-#if NET_STANDARD_2_0 || NET_4_6 || NET_2_0 || NET_2_0_SUBSET || NET_LEGACY 
+#if (NET_STANDARD_2_0 || NET_4_6 || NET_2_0 || NET_2_0_SUBSET || NET_LEGACY) && !NET_STANDARD_2_1
 
 // https://github.com/dotnet/corefx/blob/48363ac826ccf66fbe31a5dcb1dc2aab9a7dd768/src/Common/src/CoreLib/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/TypeExtensions.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/TypeExtensions.cs
@@ -7,23 +7,6 @@ namespace Newtonsoft.Json.UnityConverters.Helpers
 {
     internal static class TypeExtensions
     {
-        public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
-        {
-            try
-            {
-                return assembly.GetTypes();
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-#if DEBUG
-                Console.WriteLine("Newtonsoft.Json.UnityConverters.Helpers.TypeExtensions: "
-                    + "Failed to load some types from assembly '{assembly.FullName}'. Maybe assembly is not fully loaded yet?\n"
-                    + ex.ToString());
-#endif
-                return ex.Types.Where(t => t != null);
-            }
-        }
-
         /// <summary>
         /// Gets the non-public instance field info <see cref="FieldInfo"/> for the converted type
         /// <typeparamref name="T"/>.

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/TypeExtensions.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/TypeExtensions.cs
@@ -7,6 +7,23 @@ namespace Newtonsoft.Json.UnityConverters.Helpers
 {
     internal static class TypeExtensions
     {
+        public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+#if DEBUG
+                Console.WriteLine("Newtonsoft.Json.UnityConverters.Helpers.TypeExtensions: "
+                    + "Failed to load some types from assembly '{assembly.FullName}'. Maybe assembly is not fully loaded yet?\n"
+                    + ex.ToString());
+#endif
+                return ex.Types.Where(t => t != null);
+            }
+        }
+
         /// <summary>
         /// Gets the non-public instance field info <see cref="FieldInfo"/> for the converted type
         /// <typeparamref name="T"/>.

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -30,7 +30,9 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.UnityConverters.Configuration;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using Newtonsoft.Json.UnityConverters.Utility;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters
@@ -198,7 +200,7 @@ namespace Newtonsoft.Json.UnityConverters
         /// <returns>The types.</returns>
         internal static IEnumerable<Type> FindConverters()
         {
-#if UNITY_2019_2_OR_NEWER
+#if UNITY_2019_2_OR_NEWER && UNITY_EDITOR
             var types = UnityEditor.TypeCache.GetTypesDerivedFrom<JsonConverter>();
 #else
             var types = typeof(JsonConverter).Assembly.GetTypes();

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -141,14 +141,11 @@ namespace Newtonsoft.Json.UnityConverters
         /// <returns>The converters.</returns>
         internal static List<JsonConverter> CreateConverters(UnityConvertersConfig config)
         {
-            var watch = System.Diagnostics.Stopwatch.StartNew();
             var converterTypes = new List<Type>();
             var grouping = GroupConverters(FindConverters());
             converterTypes.AddRange(ApplyConfigFilter(grouping.outsideConverters, config.useAllOutsideConverters, config.outsideConverters));
             converterTypes.AddRange(ApplyConfigFilter(grouping.unityConverters, config.useAllUnityConverters, config.unityConverters));
             converterTypes.AddRange(ApplyConfigFilter(grouping.jsonNetConverters, config.useAllJsonNetConverters, config.jsonNetConverters));
-            watch.Stop();
-            UnityEngine.Debug.Log($"Loading converters took {watch.Elapsed}");
 
             var result = new List<JsonConverter>();
             result.AddRange(converterTypes.Select(CreateConverter));

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -142,7 +142,7 @@ namespace Newtonsoft.Json.UnityConverters
         internal static List<JsonConverter> CreateConverters(UnityConvertersConfig config)
         {
             var converterTypes = new List<Type>();
-            var grouping = GroupConverters(FindConverters());
+            var grouping = FindGroupedConverters();
             converterTypes.AddRange(ApplyConfigFilter(grouping.outsideConverters, config.useAllOutsideConverters, config.outsideConverters));
             converterTypes.AddRange(ApplyConfigFilter(grouping.unityConverters, config.useAllUnityConverters, config.unityConverters));
             converterTypes.AddRange(ApplyConfigFilter(grouping.jsonNetConverters, config.useAllJsonNetConverters, config.jsonNetConverters));
@@ -152,43 +152,9 @@ namespace Newtonsoft.Json.UnityConverters
             return result;
         }
 
-        internal struct ConverterGrouping
-        {
-            public List<Type> outsideConverters { get; set; }
-            public List<Type> unityConverters { get; set; }
-            public List<Type> jsonNetConverters { get; set; }
-        }
-
-        internal static ConverterGrouping GroupConverters(IEnumerable<Type> types)
-        {
-            var grouping = new ConverterGrouping {
-                outsideConverters = new List<Type>(),
-                unityConverters = new List<Type>(),
-                jsonNetConverters = new List<Type>(),
-            };
-
-            foreach (var converter in types)
-            {
-                if (converter.Namespace?.StartsWith("Newtonsoft.Json.UnityConverters") == true)
-                {
-                    grouping.unityConverters.Add(converter);
-                }
-                else if (converter.Namespace?.StartsWith("Newtonsoft.Json.Converters") == true)
-                {
-                    grouping.jsonNetConverters.Add(converter);
-                }
-                else
-                {
-                    grouping.outsideConverters.Add(converter);
-                }
-            }
-
-            return grouping;
-        }
-
         internal static ConverterGrouping FindGroupedConverters()
         {
-            return GroupConverters(FindConverters());
+            return ConverterGrouping.Create(FindConverters());
         }
 
         /// <summary>

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -30,9 +30,6 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.UnityConverters.Configuration;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using Newtonsoft.Json.UnityConverters.Utility;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -200,7 +200,8 @@ namespace Newtonsoft.Json.UnityConverters
 #if UNITY_2019_2_OR_NEWER && UNITY_EDITOR
             var types = UnityEditor.TypeCache.GetTypesDerivedFrom<JsonConverter>();
 #else
-            var types = typeof(JsonConverter).Assembly.GetTypes();
+            var types = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(dll => dll.GetLoadableTypes());
 #endif
             return FilterToJsonConvertersAndOrder(types);
         }


### PR DESCRIPTION
This is a second attempt at #77. I had to revert the changes from #78 because I wasn't really fond of the approach when I looked deeper into it. Also, once I got CI pipelines running again, I noticed that it was not working on some older Unity versions.

Some other changes that slipped in:

- Fixed NullableAttribute for .NET Standard 2.1
- Fixed GradientTest
- Added ResolutionConverter
- Ignore GameCenter.RangeTests obsolete warning
- Changed to use UnityEngine.TypeCache
