### PR TITLE
Feature: Unity.Mathematics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -80,7 +80,7 @@ csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:suggestion
 
 # Expression-bodied members
-csharp_style_expression_bodied_methods = false:warning
+csharp_style_expression_bodied_methods = false:silent
 csharp_style_expression_bodied_constructors = false:warning
 csharp_style_expression_bodied_operators = false:warning
 csharp_style_expression_bodied_properties = true:suggestion
@@ -129,7 +129,7 @@ csharp_new_line_between_query_expression_clauses = true
 
 # Indentation options
 csharp_indent_case_contents = true
-csharp_indent_switch_labels = false
+csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
 # Spacing options

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1de637b203792541877736f30630d29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/BoolTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/BoolTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class Bool2Tests : ValueTypeTester<bool2>
+    {
+        public static readonly IReadOnlyCollection<(bool2 deserialized, object anonymous)> representations = new (bool2, object)[] {
+            (new bool2(), new { x = false, y = false }),
+            (new bool2(true, false), new { x = true, y = false }),
+        };
+    }
+
+    public class Bool3Tests : ValueTypeTester<bool3>
+    {
+        public static readonly IReadOnlyCollection<(bool3 deserialized, object anonymous)> representations = new (bool3, object)[] {
+            (new bool3(), new { x = false, y = false, z = false }),
+            (new bool3(true, false, true), new { x = true, y = false, z = true }),
+        };
+    }
+
+    public class Bool4Tests : ValueTypeTester<bool4>
+    {
+        public static readonly IReadOnlyCollection<(bool4 deserialized, object anonymous)> representations = new (bool4, object)[] {
+            (new bool4(), new { x = false, y = false, z = false, w = false }),
+            (new bool4(true, false, true, false), new { x = true, y = false, z = true, w = false }),
+        };
+    }
+
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/BoolTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/BoolTests.cs
@@ -3,6 +3,7 @@ using Unity.Mathematics;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
 {
+    #region Vector
     public class Bool2Tests : ValueTypeTester<bool2>
     {
         public static readonly IReadOnlyCollection<(bool2 deserialized, object anonymous)> representations = new (bool2, object)[] {
@@ -26,5 +27,185 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
             (new bool4(true, false, true, false), new { x = true, y = false, z = true, w = false }),
         };
     }
+    #endregion
 
+    #region Matrix 2xN
+    public class Bool2x2Tests : ValueTypeTester<bool2x2>
+    {
+        public static readonly IReadOnlyCollection<(bool2x2 deserialized, object anonymous)> representations = new (bool2x2, object)[] {
+            (new bool2x2(), new {
+                c0 = new { x = false, y = false },
+                c1 = new { x = false, y = false },
+            }),
+            (new bool2x2(new bool2(true, false), new bool2(true, false)), new {
+                c0 = new { x = true, y = false },
+                c1 = new { x = true, y = false },
+            }),
+        };
+    }
+
+    public class Bool2x3Tests : ValueTypeTester<bool2x3>
+    {
+        public static readonly IReadOnlyCollection<(bool2x3 deserialized, object anonymous)> representations = new (bool2x3, object)[] {
+            (new bool2x3(), new {
+                c0 = new { x = false, y = false },
+                c1 = new { x = false, y = false },
+                c2 = new { x = false, y = false },
+            }),
+            (new bool2x3(
+                new bool2(true, false),
+                new bool2(true, false),
+                new bool2(true, false)
+            ), new {
+                c0 = new { x = true, y = false },
+                c1 = new { x = true, y = false },
+                c2 = new { x = true, y = false },
+            }),
+        };
+    }
+
+    public class Bool2x4Tests : ValueTypeTester<bool2x4>
+    {
+        public static readonly IReadOnlyCollection<(bool2x4 deserialized, object anonymous)> representations = new (bool2x4, object)[] {
+            (new bool2x4(), new {
+                c0 = new { x = false, y = false },
+                c1 = new { x = false, y = false },
+                c2 = new { x = false, y = false },
+                c3 = new { x = false, y = false },
+            }),
+            (new bool2x4(
+                new bool2(true, false),
+                new bool2(true, false),
+                new bool2(true, false),
+                new bool2(true, false)
+            ), new {
+                c0 = new { x = true, y = false },
+                c1 = new { x = true, y = false },
+                c2 = new { x = true, y = false },
+                c3 = new { x = true, y = false },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 3xN
+    public class Bool3x2Tests : ValueTypeTester<bool3x2>
+    {
+        public static readonly IReadOnlyCollection<(bool3x2 deserialized, object anonymous)> representations = new (bool3x2, object)[] {
+            (new bool3x2(), new {
+                c0 = new { x = false, y = false, z = false },
+                c1 = new { x = false, y = false, z = false },
+            }),
+            (new bool3x2(new bool3(true, false, true), new bool3(false, true, false)), new {
+                c0 = new { x = true, y = false, z = true },
+                c1 = new { x = false, y = true, z = false },
+            }),
+        };
+    }
+
+    public class Bool3x3Tests : ValueTypeTester<bool3x3>
+    {
+        public static readonly IReadOnlyCollection<(bool3x3 deserialized, object anonymous)> representations = new (bool3x3, object)[] {
+            (new bool3x3(), new {
+                c0 = new { x = false, y = false, z = false },
+                c1 = new { x = false, y = false, z = false },
+                c2 = new { x = false, y = false, z = false },
+            }),
+            (new bool3x3(
+                new bool3(true, false, true),
+                new bool3(false, true, false),
+                new bool3(true, false, true)
+            ), new {
+                c0 = new { x = true, y = false, z = true },
+                c1 = new { x = false, y = true, z = false },
+                c2 = new { x = true, y = false, z = true },
+            }),
+        };
+    }
+
+    public class Bool3x4Tests : ValueTypeTester<bool3x4>
+    {
+        public static readonly IReadOnlyCollection<(bool3x4 deserialized, object anonymous)> representations = new (bool3x4, object)[] {
+            (new bool3x4(), new {
+                c0 = new { x = false, y = false, z = false },
+                c1 = new { x = false, y = false, z = false },
+                c2 = new { x = false, y = false, z = false },
+                c3 = new { x = false, y = false, z = false },
+            }),
+            (new bool3x4(
+                new bool3(true, false, true),
+                new bool3(false, true, false),
+                new bool3(true, false, true),
+                new bool3(false, true, false)
+            ), new {
+                c0 = new { x = true, y = false, z = true },
+                c1 = new { x = false, y = true, z = false },
+                c2 = new { x = true, y = false, z = true },
+                c3 = new { x = false, y = true, z = false },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 4xN
+    public class Bool4x2Tests : ValueTypeTester<bool4x2>
+    {
+        public static readonly IReadOnlyCollection<(bool4x2 deserialized, object anonymous)> representations = new (bool4x2, object)[] {
+            (new bool4x2(), new {
+                c0 = new { x = false, y = false, z = false, w = false },
+                c1 = new { x = false, y = false, z = false, w = false },
+            }),
+            (new bool4x2(
+                new bool4(true, false, true, false),
+                new bool4(true, false, true, false)
+            ), new {
+                c0 = new { x = true, y = false, z = true, w = false },
+                c1 = new { x = true, y = false, z = true, w = false },
+            }),
+        };
+    }
+
+    public class Bool4x3Tests : ValueTypeTester<bool4x3>
+    {
+        public static readonly IReadOnlyCollection<(bool4x3 deserialized, object anonymous)> representations = new (bool4x3, object)[] {
+            (new bool4x3(), new {
+                c0 = new { x = false, y = false, z = false, w = false },
+                c1 = new { x = false, y = false, z = false, w = false },
+                c2 = new { x = false, y = false, z = false, w = false },
+            }),
+            (new bool4x3(
+                new bool4(true, false, true, false),
+                new bool4(true, false, true, false),
+                new bool4(true, false, true, false)
+            ), new {
+                c0 = new { x = true, y = false, z = true, w = false },
+                c1 = new { x = true, y = false, z = true, w = false },
+                c2 = new { x = true, y = false, z = true, w = false },
+            }),
+        };
+    }
+
+    public class Bool4x4Tests : ValueTypeTester<bool4x4>
+    {
+        public static readonly IReadOnlyCollection<(bool4x4 deserialized, object anonymous)> representations = new (bool4x4, object)[] {
+            (new bool4x4(), new {
+                c0 = new { x = false, y = false, z = false, w = false },
+                c1 = new { x = false, y = false, z = false, w = false },
+                c2 = new { x = false, y = false, z = false, w = false },
+                c3 = new { x = false, y = false, z = false, w = false },
+            }),
+            (new bool4x4(
+                new bool4(true, false, true, false),
+                new bool4(true, false, true, false),
+                new bool4(true, false, true, false),
+                new bool4(true, false, true, false)
+            ), new {
+                c0 = new { x = true, y = false, z = true, w = false },
+                c1 = new { x = true, y = false, z = true, w = false },
+                c2 = new { x = true, y = false, z = true, w = false },
+                c3 = new { x = true, y = false, z = true, w = false },
+            }),
+        };
+    }
+    #endregion
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/BoolTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/BoolTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b984e8a6086a93342943da19895856f7

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/DoubleTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/DoubleTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class Double2Tests : ValueTypeTester<double2>
+    {
+        public static readonly IReadOnlyCollection<(double2 deserialized, object anonymous)> representations = new (double2, object)[] {
+            (new double2(), new { x = 0f, y = 0f }),
+            (new double2(1, 2), new { x = 1f, y = 2f }),
+        };
+    }
+
+    public class Double3Tests : ValueTypeTester<double3>
+    {
+        public static readonly IReadOnlyCollection<(double3 deserialized, object anonymous)> representations = new (double3, object)[] {
+            (new double3(), new { x = 0f, y = 0f, z = 0f }),
+            (new double3(1, 2, 3), new { x = 1f, y = 2f, z = 3f }),
+        };
+    }
+
+    public class Double4Tests : ValueTypeTester<double4>
+    {
+        public static readonly IReadOnlyCollection<(double4 deserialized, object anonymous)> representations = new (double4, object)[] {
+            (new double4(), new { x = 0f, y = 0f, z = 0f, w = 0f }),
+            (new double4(1, 2, 3, 4), new { x = 1f, y = 2f, z = 3f, w = 4f }),
+        };
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/DoubleTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/DoubleTests.cs
@@ -3,6 +3,7 @@ using Unity.Mathematics;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
 {
+    #region Vector
     public class Double2Tests : ValueTypeTester<double2>
     {
         public static readonly IReadOnlyCollection<(double2 deserialized, object anonymous)> representations = new (double2, object)[] {
@@ -26,4 +27,185 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
             (new double4(1, 2, 3, 4), new { x = 1f, y = 2f, z = 3f, w = 4f }),
         };
     }
+    #endregion
+
+    #region Matrix 2xN
+    public class Double2x2Tests : ValueTypeTester<double2x2>
+    {
+        public static readonly IReadOnlyCollection<(double2x2 deserialized, object anonymous)> representations = new (double2x2, object)[] {
+            (new double2x2(), new {
+                c0 = new { x = 0f, y = 0f },
+                c1 = new { x = 0f, y = 0f },
+            }),
+            (new double2x2(new double2(1, 2), new double2(3, 4)), new {
+                c0 = new { x = 1f, y = 2f },
+                c1 = new { x = 3f, y = 4f },
+            }),
+        };
+    }
+
+    public class Double2x3Tests : ValueTypeTester<double2x3>
+    {
+        public static readonly IReadOnlyCollection<(double2x3 deserialized, object anonymous)> representations = new (double2x3, object)[] {
+            (new double2x3(), new {
+                c0 = new { x = 0f, y = 0f },
+                c1 = new { x = 0f, y = 0f },
+                c2 = new { x = 0f, y = 0f },
+            }),
+            (new double2x3(
+                new double2(1, 2),
+                new double2(3, 4),
+                new double2(5, 6)
+            ), new {
+                c0 = new { x = 1f, y = 2f },
+                c1 = new { x = 3f, y = 4f },
+                c2 = new { x = 5f, y = 6f },
+            }),
+        };
+    }
+
+    public class Double2x4Tests : ValueTypeTester<double2x4>
+    {
+        public static readonly IReadOnlyCollection<(double2x4 deserialized, object anonymous)> representations = new (double2x4, object)[] {
+            (new double2x4(), new {
+                c0 = new { x = 0f, y = 0f },
+                c1 = new { x = 0f, y = 0f },
+                c2 = new { x = 0f, y = 0f },
+                c3 = new { x = 0f, y = 0f },
+            }),
+            (new double2x4(
+                new double2(1, 2),
+                new double2(3, 4),
+                new double2(5, 6),
+                new double2(7, 8)
+            ), new {
+                c0 = new { x = 1f, y = 2f },
+                c1 = new { x = 3f, y = 4f },
+                c2 = new { x = 5f, y = 6f },
+                c3 = new { x = 7f, y = 8f },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 3xN
+    public class Double3x2Tests : ValueTypeTester<double3x2>
+    {
+        public static readonly IReadOnlyCollection<(double3x2 deserialized, object anonymous)> representations = new (double3x2, object)[] {
+            (new double3x2(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f },
+            }),
+            (new double3x2(new double3(1, 2, 3), new double3(4, 5, 6)), new {
+                c0 = new { x = 1f, y = 2f, z = 3f },
+                c1 = new { x = 4f, y = 5f, z = 6f },
+            }),
+        };
+    }
+
+    public class Double3x3Tests : ValueTypeTester<double3x3>
+    {
+        public static readonly IReadOnlyCollection<(double3x3 deserialized, object anonymous)> representations = new (double3x3, object)[] {
+            (new double3x3(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f },
+            }),
+            (new double3x3(
+                new double3(1, 2, 3),
+                new double3(4, 5, 6),
+                new double3(7, 8, 9)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f },
+                c1 = new { x = 4f, y = 5f, z = 6f },
+                c2 = new { x = 7f, y = 8f, z = 9f },
+            }),
+        };
+    }
+
+    public class Double3x4Tests : ValueTypeTester<double3x4>
+    {
+        public static readonly IReadOnlyCollection<(double3x4 deserialized, object anonymous)> representations = new (double3x4, object)[] {
+            (new double3x4(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f },
+                c3 = new { x = 0f, y = 0f, z = 0f },
+            }),
+            (new double3x4(
+                new double3(1, 2, 3),
+                new double3(4, 5, 6),
+                new double3(7, 8, 9),
+                new double3(10, 11, 12)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f },
+                c1 = new { x = 4f, y = 5f, z = 6f },
+                c2 = new { x = 7f, y = 8f, z = 9f },
+                c3 = new { x = 10f, y = 11f, z = 12f },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 4xN
+    public class Double4x2Tests : ValueTypeTester<double4x2>
+    {
+        public static readonly IReadOnlyCollection<(double4x2 deserialized, object anonymous)> representations = new (double4x2, object)[] {
+            (new double4x2(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+            }),
+            (new double4x2(
+                new double4(1, 2, 3, 4),
+                new double4(5, 6, 7, 8)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f, w = 4f },
+                c1 = new { x = 5f, y = 6f, z = 7f, w = 8f },
+            }),
+        };
+    }
+
+    public class Double4x3Tests : ValueTypeTester<double4x3>
+    {
+        public static readonly IReadOnlyCollection<(double4x3 deserialized, object anonymous)> representations = new (double4x3, object)[] {
+            (new double4x3(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+            }),
+            (new double4x3(
+                new double4(1, 2, 3, 4),
+                new double4(5, 6, 7, 8),
+                new double4(9, 10, 11, 12)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f, w = 4f },
+                c1 = new { x = 5f, y = 6f, z = 7f, w = 8f },
+                c2 = new { x = 9f, y = 10f, z = 11f, w = 12f },
+            }),
+        };
+    }
+
+    public class Double4x4Tests : ValueTypeTester<double4x4>
+    {
+        public static readonly IReadOnlyCollection<(double4x4 deserialized, object anonymous)> representations = new (double4x4, object)[] {
+            (new double4x4(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c3 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+            }),
+            (new double4x4(
+                new double4(1, 2, 3, 4),
+                new double4(5, 6, 7, 8),
+                new double4(9, 10, 11, 12),
+                new double4(13, 14, 15, 16)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f, w = 4f },
+                c1 = new { x = 5f, y = 6f, z = 7f, w = 8f },
+                c2 = new { x = 9f, y = 10f, z = 11f, w = 12f },
+                c3 = new { x = 13f, y = 14f, z = 15f, w = 16f },
+            }),
+        };
+    }
+    #endregion
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/DoubleTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/DoubleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d634e7306cb015146bba7b2e61e7d1df

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/FloatTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/FloatTests.cs
@@ -3,6 +3,7 @@ using Unity.Mathematics;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
 {
+    #region Vector
     public class Float2Tests : ValueTypeTester<float2>
     {
         public static readonly IReadOnlyCollection<(float2 deserialized, object anonymous)> representations = new (float2, object)[] {
@@ -26,4 +27,185 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
             (new float4(1, 2, 3, 4), new { x = 1f, y = 2f, z = 3f, w = 4f }),
         };
     }
+    #endregion
+
+    #region Matrix 2xN
+    public class Float2x2Tests : ValueTypeTester<float2x2>
+    {
+        public static readonly IReadOnlyCollection<(float2x2 deserialized, object anonymous)> representations = new (float2x2, object)[] {
+            (new float2x2(), new {
+                c0 = new { x = 0f, y = 0f },
+                c1 = new { x = 0f, y = 0f },
+            }),
+            (new float2x2(new float2(1, 2), new float2(3, 4)), new {
+                c0 = new { x = 1f, y = 2f },
+                c1 = new { x = 3f, y = 4f },
+            }),
+        };
+    }
+
+    public class Float2x3Tests : ValueTypeTester<float2x3>
+    {
+        public static readonly IReadOnlyCollection<(float2x3 deserialized, object anonymous)> representations = new (float2x3, object)[] {
+            (new float2x3(), new {
+                c0 = new { x = 0f, y = 0f },
+                c1 = new { x = 0f, y = 0f },
+                c2 = new { x = 0f, y = 0f },
+            }),
+            (new float2x3(
+                new float2(1, 2),
+                new float2(3, 4),
+                new float2(5, 6)
+            ), new {
+                c0 = new { x = 1f, y = 2f },
+                c1 = new { x = 3f, y = 4f },
+                c2 = new { x = 5f, y = 6f },
+            }),
+        };
+    }
+
+    public class Float2x4Tests : ValueTypeTester<float2x4>
+    {
+        public static readonly IReadOnlyCollection<(float2x4 deserialized, object anonymous)> representations = new (float2x4, object)[] {
+            (new float2x4(), new {
+                c0 = new { x = 0f, y = 0f },
+                c1 = new { x = 0f, y = 0f },
+                c2 = new { x = 0f, y = 0f },
+                c3 = new { x = 0f, y = 0f },
+            }),
+            (new float2x4(
+                new float2(1, 2),
+                new float2(3, 4),
+                new float2(5, 6),
+                new float2(7, 8)
+            ), new {
+                c0 = new { x = 1f, y = 2f },
+                c1 = new { x = 3f, y = 4f },
+                c2 = new { x = 5f, y = 6f },
+                c3 = new { x = 7f, y = 8f },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 3xN
+    public class Float3x2Tests : ValueTypeTester<float3x2>
+    {
+        public static readonly IReadOnlyCollection<(float3x2 deserialized, object anonymous)> representations = new (float3x2, object)[] {
+            (new float3x2(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f },
+            }),
+            (new float3x2(new float3(1, 2, 3), new float3(4, 5, 6)), new {
+                c0 = new { x = 1f, y = 2f, z = 3f },
+                c1 = new { x = 4f, y = 5f, z = 6f },
+            }),
+        };
+    }
+
+    public class Float3x3Tests : ValueTypeTester<float3x3>
+    {
+        public static readonly IReadOnlyCollection<(float3x3 deserialized, object anonymous)> representations = new (float3x3, object)[] {
+            (new float3x3(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f },
+            }),
+            (new float3x3(
+                new float3(1, 2, 3),
+                new float3(4, 5, 6),
+                new float3(7, 8, 9)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f },
+                c1 = new { x = 4f, y = 5f, z = 6f },
+                c2 = new { x = 7f, y = 8f, z = 9f },
+            }),
+        };
+    }
+
+    public class Float3x4Tests : ValueTypeTester<float3x4>
+    {
+        public static readonly IReadOnlyCollection<(float3x4 deserialized, object anonymous)> representations = new (float3x4, object)[] {
+            (new float3x4(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f },
+                c3 = new { x = 0f, y = 0f, z = 0f },
+            }),
+            (new float3x4(
+                new float3(1, 2, 3),
+                new float3(4, 5, 6),
+                new float3(7, 8, 9),
+                new float3(10, 11, 12)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f },
+                c1 = new { x = 4f, y = 5f, z = 6f },
+                c2 = new { x = 7f, y = 8f, z = 9f },
+                c3 = new { x = 10f, y = 11f, z = 12f },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 4xN
+    public class Float4x2Tests : ValueTypeTester<float4x2>
+    {
+        public static readonly IReadOnlyCollection<(float4x2 deserialized, object anonymous)> representations = new (float4x2, object)[] {
+            (new float4x2(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+            }),
+            (new float4x2(
+                new float4(1, 2, 3, 4),
+                new float4(5, 6, 7, 8)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f, w = 4f },
+                c1 = new { x = 5f, y = 6f, z = 7f, w = 8f },
+            }),
+        };
+    }
+
+    public class Float4x3Tests : ValueTypeTester<float4x3>
+    {
+        public static readonly IReadOnlyCollection<(float4x3 deserialized, object anonymous)> representations = new (float4x3, object)[] {
+            (new float4x3(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+            }),
+            (new float4x3(
+                new float4(1, 2, 3, 4),
+                new float4(5, 6, 7, 8),
+                new float4(9, 10, 11, 12)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f, w = 4f },
+                c1 = new { x = 5f, y = 6f, z = 7f, w = 8f },
+                c2 = new { x = 9f, y = 10f, z = 11f, w = 12f },
+            }),
+        };
+    }
+
+    public class Float4x4Tests : ValueTypeTester<float4x4>
+    {
+        public static readonly IReadOnlyCollection<(float4x4 deserialized, object anonymous)> representations = new (float4x4, object)[] {
+            (new float4x4(), new {
+                c0 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c1 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c2 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+                c3 = new { x = 0f, y = 0f, z = 0f, w = 0f },
+            }),
+            (new float4x4(
+                new float4(1, 2, 3, 4),
+                new float4(5, 6, 7, 8),
+                new float4(9, 10, 11, 12),
+                new float4(13, 14, 15, 16)
+            ), new {
+                c0 = new { x = 1f, y = 2f, z = 3f, w = 4f },
+                c1 = new { x = 5f, y = 6f, z = 7f, w = 8f },
+                c2 = new { x = 9f, y = 10f, z = 11f, w = 12f },
+                c3 = new { x = 13f, y = 14f, z = 15f, w = 16f },
+            }),
+        };
+    }
+    #endregion
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/FloatTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/FloatTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class Float2Tests : ValueTypeTester<float2>
+    {
+        public static readonly IReadOnlyCollection<(float2 deserialized, object anonymous)> representations = new (float2, object)[] {
+            (new float2(), new { x = 0f, y = 0f }),
+            (new float2(1, 2), new { x = 1f, y = 2f }),
+        };
+    }
+
+    public class Float3Tests : ValueTypeTester<float3>
+    {
+        public static readonly IReadOnlyCollection<(float3 deserialized, object anonymous)> representations = new (float3, object)[] {
+            (new float3(), new { x = 0f, y = 0f, z = 0f }),
+            (new float3(1, 2, 3), new { x = 1f, y = 2f, z = 3f }),
+        };
+    }
+
+    public class Float4Tests : ValueTypeTester<float4>
+    {
+        public static readonly IReadOnlyCollection<(float4 deserialized, object anonymous)> representations = new (float4, object)[] {
+            (new float4(), new { x = 0f, y = 0f, z = 0f, w = 0f }),
+            (new float4(1, 2, 3, 4), new { x = 1f, y = 2f, z = 3f, w = 4f }),
+        };
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/FloatTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/FloatTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97ef830850111004a9045d97fd407813

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class HalfTests : ValueTypeTester<half>
+    {
+        public static readonly IReadOnlyCollection<(half deserialized, object anonymous)> representations = new (half, object)[] {
+            (new half(), 0f),
+            (new half(1), 1),
+        };
+    }
+
+    public class Half2Tests : ValueTypeTester<half2>
+    {
+        public static readonly IReadOnlyCollection<(half2 deserialized, object anonymous)> representations = new (half2, object)[] {
+            (new half2(), new { x = 0f, y = 0f }),
+            (new half2(new half(1), new half(2)), new { x = 1f, y = 2f }),
+        };
+    }
+
+    public class Half3Tests : ValueTypeTester<half3>
+    {
+        public static readonly IReadOnlyCollection<(half3 deserialized, object anonymous)> representations = new (half3, object)[] {
+            (new half3(), new { x = 0f, y = 0f, z = 0f }),
+            (new half3(new half(1), new half(2), new half(3)), new { x = 1f, y = 2f, z = 3f }),
+        };
+    }
+
+    public class Half4Tests : ValueTypeTester<half4>
+    {
+        public static readonly IReadOnlyCollection<(half4 deserialized, object anonymous)> representations = new (half4, object)[] {
+            (new half4(), new { x = 0f, y = 0f, z = 0f, w = 0f }),
+            (new half4(new half(1), new half(2), new half(3), new half(4)), new { x = 1f, y = 2f, z = 3f, w = 4f }),
+        };
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs
@@ -3,11 +3,28 @@ using Unity.Mathematics;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
 {
-    public class HalfTests : ValueTypeTester<half>
+    public struct HalfWrapper
     {
-        public static readonly IReadOnlyCollection<(half deserialized, object anonymous)> representations = new (half, object)[] {
-            (new half(), 0f),
-            (new half(1), 1),
+        public half half;
+
+        public HalfWrapper(half half)
+        {
+            this.half = half;
+        }
+
+        public override string ToString()
+        {
+            return half.ToString();
+        }
+    }
+
+    // Have to use a wrapper type, as Json.NET ignores the converters when
+    // targeting a single scalar type.
+    public class HalfTests : ValueTypeTester<HalfWrapper>
+    {
+        public static readonly IReadOnlyCollection<(HalfWrapper deserialized, object anonymous)> representations = new (HalfWrapper, object)[] {
+            (new HalfWrapper(new half()), new {half = 0f}),
+            (new HalfWrapper(new half(1)), new {half = 1f}),
         };
     }
 

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs
@@ -18,6 +18,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
         }
     }
 
+    #region Vector
     // Have to use a wrapper type, as Json.NET ignores the converters when
     // targeting a single scalar type.
     public class HalfTests : ValueTypeTester<HalfWrapper>
@@ -51,4 +52,5 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
             (new half4(new half(1), new half(2), new half(3), new half(4)), new { x = 1f, y = 2f, z = 3f, w = 4f }),
         };
     }
+    #endregion
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/HalfTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 276d0653d9e96b545b75d8967a37ac40

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class Int2Tests : ValueTypeTester<int2>
+    {
+        public static readonly IReadOnlyCollection<(int2 deserialized, object anonymous)> representations = new (int2, object)[] {
+            (new int2(), new { x = 0, y = 0 }),
+            (new int2(1, 2), new { x = 1, y = 2 }),
+        };
+    }
+
+    public class Int3Tests : ValueTypeTester<int3>
+    {
+        public static readonly IReadOnlyCollection<(int3 deserialized, object anonymous)> representations = new (int3, object)[] {
+            (new int3(), new { x = 0, y = 0, z = 0 }),
+            (new int3(1, 2, 3), new { x = 1, y = 2, z = 3 }),
+        };
+    }
+
+    public class Int4Tests : ValueTypeTester<int4>
+    {
+        public static readonly IReadOnlyCollection<(int4 deserialized, object anonymous)> representations = new (int4, object)[] {
+            (new int4(), new { x = 0, y = 0, z = 0, w = 4 }),
+            (new int4(1, 2, 3,4), new { x = 1, y = 2, z = 3, w = 4 }),
+        };
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs
@@ -3,6 +3,7 @@ using Unity.Mathematics;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
 {
+    #region Vector
     public class Int2Tests : ValueTypeTester<int2>
     {
         public static readonly IReadOnlyCollection<(int2 deserialized, object anonymous)> representations = new (int2, object)[] {
@@ -26,4 +27,185 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
             (new int4(1, 2, 3,4), new { x = 1, y = 2, z = 3, w = 4 }),
         };
     }
+    #endregion
+
+    #region Matrix 2xN
+    public class Int2x2Tests : ValueTypeTester<int2x2>
+    {
+        public static readonly IReadOnlyCollection<(int2x2 deserialized, object anonymous)> representations = new (int2x2, object)[] {
+            (new int2x2(), new {
+                c0 = new { x = 0, y = 0 },
+                c1 = new { x = 0, y = 0 },
+            }),
+            (new int2x2(new int2(1, 2), new int2(3, 4)), new {
+                c0 = new { x = 1, y = 2 },
+                c1 = new { x = 3, y = 4 },
+            }),
+        };
+    }
+
+    public class Int2x3Tests : ValueTypeTester<int2x3>
+    {
+        public static readonly IReadOnlyCollection<(int2x3 deserialized, object anonymous)> representations = new (int2x3, object)[] {
+            (new int2x3(), new {
+                c0 = new { x = 0, y = 0 },
+                c1 = new { x = 0, y = 0 },
+                c2 = new { x = 0, y = 0 },
+            }),
+            (new int2x3(
+                new int2(1, 2),
+                new int2(3, 4),
+                new int2(5, 6)
+            ), new {
+                c0 = new { x = 1, y = 2 },
+                c1 = new { x = 3, y = 4 },
+                c2 = new { x = 5, y = 6 },
+            }),
+        };
+    }
+
+    public class Int2x4Tests : ValueTypeTester<int2x4>
+    {
+        public static readonly IReadOnlyCollection<(int2x4 deserialized, object anonymous)> representations = new (int2x4, object)[] {
+            (new int2x4(), new {
+                c0 = new { x = 0, y = 0 },
+                c1 = new { x = 0, y = 0 },
+                c2 = new { x = 0, y = 0 },
+                c3 = new { x = 0, y = 0 },
+            }),
+            (new int2x4(
+                new int2(1, 2),
+                new int2(3, 4),
+                new int2(5, 6),
+                new int2(7, 8)
+            ), new {
+                c0 = new { x = 1, y = 2 },
+                c1 = new { x = 3, y = 4 },
+                c2 = new { x = 5, y = 6 },
+                c3 = new { x = 7, y = 8 },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 3xN
+    public class Int3x2Tests : ValueTypeTester<int3x2>
+    {
+        public static readonly IReadOnlyCollection<(int3x2 deserialized, object anonymous)> representations = new (int3x2, object)[] {
+            (new int3x2(), new {
+                c0 = new { x = 0, y = 0, z = 0 },
+                c1 = new { x = 0, y = 0, z = 0 },
+            }),
+            (new int3x2(new int3(1, 2, 3), new int3(4, 5, 6)), new {
+                c0 = new { x = 1, y = 2, z = 3 },
+                c1 = new { x = 4, y = 5, z = 6 },
+            }),
+        };
+    }
+
+    public class Int3x3Tests : ValueTypeTester<int3x3>
+    {
+        public static readonly IReadOnlyCollection<(int3x3 deserialized, object anonymous)> representations = new (int3x3, object)[] {
+            (new int3x3(), new {
+                c0 = new { x = 0, y = 0, z = 0 },
+                c1 = new { x = 0, y = 0, z = 0 },
+                c2 = new { x = 0, y = 0, z = 0 },
+            }),
+            (new int3x3(
+                new int3(1, 2, 3),
+                new int3(4, 5, 6),
+                new int3(7, 8, 9)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3 },
+                c1 = new { x = 4, y = 5, z = 6 },
+                c2 = new { x = 7, y = 8, z = 9 },
+            }),
+        };
+    }
+
+    public class Int3x4Tests : ValueTypeTester<int3x4>
+    {
+        public static readonly IReadOnlyCollection<(int3x4 deserialized, object anonymous)> representations = new (int3x4, object)[] {
+            (new int3x4(), new {
+                c0 = new { x = 0, y = 0, z = 0 },
+                c1 = new { x = 0, y = 0, z = 0 },
+                c2 = new { x = 0, y = 0, z = 0 },
+                c3 = new { x = 0, y = 0, z = 0 },
+            }),
+            (new int3x4(
+                new int3(1, 2, 3),
+                new int3(4, 5, 6),
+                new int3(7, 8, 9),
+                new int3(10, 11, 12)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3 },
+                c1 = new { x = 4, y = 5, z = 6 },
+                c2 = new { x = 7, y = 8, z = 9 },
+                c3 = new { x = 10, y = 11, z = 12 },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 4xN
+    public class Int4x2Tests : ValueTypeTester<int4x2>
+    {
+        public static readonly IReadOnlyCollection<(int4x2 deserialized, object anonymous)> representations = new (int4x2, object)[] {
+            (new int4x2(), new {
+                c0 = new { x = 0, y = 0, z = 0, w = 0 },
+                c1 = new { x = 0, y = 0, z = 0, w = 0 },
+            }),
+            (new int4x2(
+                new int4(1, 2, 3, 4),
+                new int4(5, 6, 7, 8)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3, w = 4 },
+                c1 = new { x = 5, y = 6, z = 7, w = 8 },
+            }),
+        };
+    }
+
+    public class Int4x3Tests : ValueTypeTester<int4x3>
+    {
+        public static readonly IReadOnlyCollection<(int4x3 deserialized, object anonymous)> representations = new (int4x3, object)[] {
+            (new int4x3(), new {
+                c0 = new { x = 0, y = 0, z = 0, w = 0 },
+                c1 = new { x = 0, y = 0, z = 0, w = 0 },
+                c2 = new { x = 0, y = 0, z = 0, w = 0 },
+            }),
+            (new int4x3(
+                new int4(1, 2, 3, 4),
+                new int4(5, 6, 7, 8),
+                new int4(9, 10, 11, 12)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3, w = 4 },
+                c1 = new { x = 5, y = 6, z = 7, w = 8 },
+                c2 = new { x = 9, y = 10, z = 11, w = 12 },
+            }),
+        };
+    }
+
+    public class Int4x4Tests : ValueTypeTester<int4x4>
+    {
+        public static readonly IReadOnlyCollection<(int4x4 deserialized, object anonymous)> representations = new (int4x4, object)[] {
+            (new int4x4(), new {
+                c0 = new { x = 0, y = 0, z = 0, w = 0 },
+                c1 = new { x = 0, y = 0, z = 0, w = 0 },
+                c2 = new { x = 0, y = 0, z = 0, w = 0 },
+                c3 = new { x = 0, y = 0, z = 0, w = 0 },
+            }),
+            (new int4x4(
+                new int4(1, 2, 3, 4),
+                new int4(5, 6, 7, 8),
+                new int4(9, 10, 11, 12),
+                new int4(13, 14, 15, 16)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3, w = 4 },
+                c1 = new { x = 5, y = 6, z = 7, w = 8 },
+                c2 = new { x = 9, y = 10, z = 11, w = 12 },
+                c3 = new { x = 13, y = 14, z = 15, w = 16 },
+            }),
+        };
+    }
+    #endregion
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs
@@ -22,7 +22,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
     public class Int4Tests : ValueTypeTester<int4>
     {
         public static readonly IReadOnlyCollection<(int4 deserialized, object anonymous)> representations = new (int4, object)[] {
-            (new int4(), new { x = 0, y = 0, z = 0, w = 4 }),
+            (new int4(), new { x = 0, y = 0, z = 0, w = 0 }),
             (new int4(1, 2, 3,4), new { x = 1, y = 2, z = 3, w = 4 }),
         };
     }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/IntTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f1a083271be3cd44a28160c07e5a5d4

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/Newtonsoft.Json.UnityConverters.Tests.Mathematics.asmdef
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/Newtonsoft.Json.UnityConverters.Tests.Mathematics.asmdef
@@ -1,0 +1,34 @@
+{
+    "name": "Newtonsoft.Json.UnityConverters.Tests.Mathematics",
+    "rootNamespace": "",
+    "references": [
+        "Newtonsoft.Json.UnityConverters.Tests",
+        "Newtonsoft.Json.UnityConverters",
+        "Newtonsoft.Json.UnityConverters.Addressables",
+        "Newtonsoft.Json.UnityConverters.Mathematics",
+        "Unity.Mathematics",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll",
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "HAVE_MODULE_MATHEMATICS",
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.mathematics",
+            "expression": "",
+            "define": "HAVE_MODULE_MATHEMATICS"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/Newtonsoft.Json.UnityConverters.Tests.Mathematics.asmdef.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/Newtonsoft.Json.UnityConverters.Tests.Mathematics.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e96e797ea2e918546acecbdfb7ee0b69
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/QuaternionTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/QuaternionTests.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class QuaternionTests : ValueTypeTester<quaternion>
+    {
+        public static readonly IReadOnlyCollection<(quaternion deserialized, object anonymous)> representations = new (quaternion, object)[] {
+            (new quaternion(), new { x = 0f, y = 0f, z = 0f, w = 0f }),
+            (new quaternion(1, 2, 3, 4), new { x = 1f, y = 2f, z = 3f, w = 4f }),
+        };
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/QuaternionTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/QuaternionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 222970a9e39e3f742a3dc9fb524efecc

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
+{
+    public class Uint2Tests : ValueTypeTester<uint2>
+    {
+        public static readonly IReadOnlyCollection<(uint2 deserialized, object anonymous)> representations = new (uint2, object)[] {
+            (new uint2(), new { x = 0, y = 0 }),
+            (new uint2(1, 2), new { x = 1, y = 2 }),
+        };
+    }
+
+    public class Uint3Tests : ValueTypeTester<uint3>
+    {
+        public static readonly IReadOnlyCollection<(uint3 deserialized, object anonymous)> representations = new (uint3, object)[] {
+            (new uint3(), new { x = 0, y = 0, z = 0 }),
+            (new uint3(1, 2, 3), new { x = 1, y = 2, z = 3 }),
+        };
+    }
+
+    public class Uint4Tests : ValueTypeTester<uint4>
+    {
+        public static readonly IReadOnlyCollection<(uint4 deserialized, object anonymous)> representations = new (uint4, object)[] {
+            (new uint4(), new { x = 0, y = 0, z = 0, w = 4 }),
+            (new uint4(1, 2, 3,4), new { x = 1, y = 2, z = 3, w = 4 }),
+        };
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs
@@ -3,6 +3,7 @@ using Unity.Mathematics;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
 {
+    #region Vector
     public class Uint2Tests : ValueTypeTester<uint2>
     {
         public static readonly IReadOnlyCollection<(uint2 deserialized, object anonymous)> representations = new (uint2, object)[] {
@@ -26,4 +27,185 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
             (new uint4(1, 2, 3,4), new { x = 1, y = 2, z = 3, w = 4 }),
         };
     }
+    #endregion
+
+    #region Matrix 2xN
+    public class Uint2x2Tests : ValueTypeTester<uint2x2>
+    {
+        public static readonly IReadOnlyCollection<(uint2x2 deserialized, object anonymous)> representations = new (uint2x2, object)[] {
+            (new uint2x2(), new {
+                c0 = new { x = 0, y = 0 },
+                c1 = new { x = 0, y = 0 },
+            }),
+            (new uint2x2(new uint2(1, 2), new uint2(3, 4)), new {
+                c0 = new { x = 1, y = 2 },
+                c1 = new { x = 3, y = 4 },
+            }),
+        };
+    }
+
+    public class Uint2x3Tests : ValueTypeTester<uint2x3>
+    {
+        public static readonly IReadOnlyCollection<(uint2x3 deserialized, object anonymous)> representations = new (uint2x3, object)[] {
+            (new uint2x3(), new {
+                c0 = new { x = 0, y = 0 },
+                c1 = new { x = 0, y = 0 },
+                c2 = new { x = 0, y = 0 },
+            }),
+            (new uint2x3(
+                new uint2(1, 2),
+                new uint2(3, 4),
+                new uint2(5, 6)
+            ), new {
+                c0 = new { x = 1, y = 2 },
+                c1 = new { x = 3, y = 4 },
+                c2 = new { x = 5, y = 6 },
+            }),
+        };
+    }
+
+    public class Uint2x4Tests : ValueTypeTester<uint2x4>
+    {
+        public static readonly IReadOnlyCollection<(uint2x4 deserialized, object anonymous)> representations = new (uint2x4, object)[] {
+            (new uint2x4(), new {
+                c0 = new { x = 0, y = 0 },
+                c1 = new { x = 0, y = 0 },
+                c2 = new { x = 0, y = 0 },
+                c3 = new { x = 0, y = 0 },
+            }),
+            (new uint2x4(
+                new uint2(1, 2),
+                new uint2(3, 4),
+                new uint2(5, 6),
+                new uint2(7, 8)
+            ), new {
+                c0 = new { x = 1, y = 2 },
+                c1 = new { x = 3, y = 4 },
+                c2 = new { x = 5, y = 6 },
+                c3 = new { x = 7, y = 8 },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 3xN
+    public class Uint3x2Tests : ValueTypeTester<uint3x2>
+    {
+        public static readonly IReadOnlyCollection<(uint3x2 deserialized, object anonymous)> representations = new (uint3x2, object)[] {
+            (new uint3x2(), new {
+                c0 = new { x = 0, y = 0, z = 0 },
+                c1 = new { x = 0, y = 0, z = 0 },
+            }),
+            (new uint3x2(new uint3(1, 2, 3), new uint3(4, 5, 6)), new {
+                c0 = new { x = 1, y = 2, z = 3 },
+                c1 = new { x = 4, y = 5, z = 6 },
+            }),
+        };
+    }
+
+    public class Uint3x3Tests : ValueTypeTester<uint3x3>
+    {
+        public static readonly IReadOnlyCollection<(uint3x3 deserialized, object anonymous)> representations = new (uint3x3, object)[] {
+            (new uint3x3(), new {
+                c0 = new { x = 0, y = 0, z = 0 },
+                c1 = new { x = 0, y = 0, z = 0 },
+                c2 = new { x = 0, y = 0, z = 0 },
+            }),
+            (new uint3x3(
+                new uint3(1, 2, 3),
+                new uint3(4, 5, 6),
+                new uint3(7, 8, 9)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3 },
+                c1 = new { x = 4, y = 5, z = 6 },
+                c2 = new { x = 7, y = 8, z = 9 },
+            }),
+        };
+    }
+
+    public class Uint3x4Tests : ValueTypeTester<uint3x4>
+    {
+        public static readonly IReadOnlyCollection<(uint3x4 deserialized, object anonymous)> representations = new (uint3x4, object)[] {
+            (new uint3x4(), new {
+                c0 = new { x = 0, y = 0, z = 0 },
+                c1 = new { x = 0, y = 0, z = 0 },
+                c2 = new { x = 0, y = 0, z = 0 },
+                c3 = new { x = 0, y = 0, z = 0 },
+            }),
+            (new uint3x4(
+                new uint3(1, 2, 3),
+                new uint3(4, 5, 6),
+                new uint3(7, 8, 9),
+                new uint3(10, 11, 12)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3 },
+                c1 = new { x = 4, y = 5, z = 6 },
+                c2 = new { x = 7, y = 8, z = 9 },
+                c3 = new { x = 10, y = 11, z = 12 },
+            }),
+        };
+    }
+    #endregion
+
+    #region Matrix 4xN
+    public class Uint4x2Tests : ValueTypeTester<uint4x2>
+    {
+        public static readonly IReadOnlyCollection<(uint4x2 deserialized, object anonymous)> representations = new (uint4x2, object)[] {
+            (new uint4x2(), new {
+                c0 = new { x = 0, y = 0, z = 0, w = 0 },
+                c1 = new { x = 0, y = 0, z = 0, w = 0 },
+            }),
+            (new uint4x2(
+                new uint4(1, 2, 3, 4),
+                new uint4(5, 6, 7, 8)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3, w = 4 },
+                c1 = new { x = 5, y = 6, z = 7, w = 8 },
+            }),
+        };
+    }
+
+    public class Uint4x3Tests : ValueTypeTester<uint4x3>
+    {
+        public static readonly IReadOnlyCollection<(uint4x3 deserialized, object anonymous)> representations = new (uint4x3, object)[] {
+            (new uint4x3(), new {
+                c0 = new { x = 0, y = 0, z = 0, w = 0 },
+                c1 = new { x = 0, y = 0, z = 0, w = 0 },
+                c2 = new { x = 0, y = 0, z = 0, w = 0 },
+            }),
+            (new uint4x3(
+                new uint4(1, 2, 3, 4),
+                new uint4(5, 6, 7, 8),
+                new uint4(9, 10, 11, 12)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3, w = 4 },
+                c1 = new { x = 5, y = 6, z = 7, w = 8 },
+                c2 = new { x = 9, y = 10, z = 11, w = 12 },
+            }),
+        };
+    }
+
+    public class Uint4x4Tests : ValueTypeTester<uint4x4>
+    {
+        public static readonly IReadOnlyCollection<(uint4x4 deserialized, object anonymous)> representations = new (uint4x4, object)[] {
+            (new uint4x4(), new {
+                c0 = new { x = 0, y = 0, z = 0, w = 0 },
+                c1 = new { x = 0, y = 0, z = 0, w = 0 },
+                c2 = new { x = 0, y = 0, z = 0, w = 0 },
+                c3 = new { x = 0, y = 0, z = 0, w = 0 },
+            }),
+            (new uint4x4(
+                new uint4(1, 2, 3, 4),
+                new uint4(5, 6, 7, 8),
+                new uint4(9, 10, 11, 12),
+                new uint4(13, 14, 15, 16)
+            ), new {
+                c0 = new { x = 1, y = 2, z = 3, w = 4 },
+                c1 = new { x = 5, y = 6, z = 7, w = 8 },
+                c2 = new { x = 9, y = 10, z = 11, w = 12 },
+                c3 = new { x = 13, y = 14, z = 15, w = 16 },
+            }),
+        };
+    }
+    #endregion
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs
@@ -22,7 +22,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Mathematics
     public class Uint4Tests : ValueTypeTester<uint4>
     {
         public static readonly IReadOnlyCollection<(uint4 deserialized, object anonymous)> representations = new (uint4, object)[] {
-            (new uint4(), new { x = 0, y = 0, z = 0, w = 4 }),
+            (new uint4(), new { x = 0, y = 0, z = 0, w = 0 }),
             (new uint4(1, 2, 3,4), new { x = 1, y = 2, z = 3, w = 4 }),
         };
     }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Mathematics/UintTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c3a9529db624c043ac3c5d5b485538c

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/TypeTester.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/TypeTester.cs
@@ -138,6 +138,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests
         {
             // Arrange
             string input = Serialize(representation.anonymous);
+            TestContext.WriteLine($"Input given: '{input}'");
 
             // Act
             T result = Deserialize<T>(input);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.6.0 (WIP)
 
+- Added converters for [Unity.Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/manual/index.html).
+  This includes all the `float2`, `double3`, `int4`, `bool4`, and similar types.
+  ([#80](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/80))
+
+  There are no custom converters for the matrix types
+  (`float2x2`, `float2x3`, etc), as they currently work out-of-the-box.
+
 - Added `ResolutionConverter` to be able to read JSON from older Unity
   versions. ([#79](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/79))
 

--- a/Doc/Compatability-table.md
+++ b/Doc/Compatability-table.md
@@ -110,10 +110,18 @@ https://beautifuldingbats.com/superscript-generator/
 
 7. ✔<a name="note-7"></a> Support for Addressables package, which was added in
   v1.4.0, is only automatically included if your Unity project has imported the
-  `com.unity.addressable` package. This automatic inclusion  relies on
+  `com.unity.addressable` package. This automatic inclusion relies on
   AssemblyDefinition version defines, which was introduced in Unity 2019.1.x.
   To enable the `AssetReferenceConverter` in earlier versions of Unity, please
   add `HAVE_MODULE_ADDRESSABLES` to your project's "Scripting Define Symbols"
+  found in the "Project Settings" -> "Player" -> "Other Settings" panel.
+
+8. ✔<a name="note-8"></a> Support for Mathematics package, which was added in
+  v1.6.0, is only automatically included if your Unity project has imported the
+  `com.unity.mathematics` package. This automatic inclusion relies on
+  AssemblyDefinition version defines, which was introduced in Unity 2019.1.x.
+  To enable for example the `Float3Converter` in earlier versions of Unity,
+  please add `HAVE_MODULE_MATHEMATICS` to your project's "Scripting Define Symbols"
   found in the "Project Settings" -> "Player" -> "Other Settings" panel.
 
 ## Legend

--- a/Doc/Compatability-table.md
+++ b/Doc/Compatability-table.md
@@ -35,14 +35,20 @@ https://beautifuldingbats.com/superscript-generator/
 | Math           | *UnityEngine*.**Gradient**                                      | ✔               | ✔               | ✖[⁽¹⁾](#note-1)  |
 | Math           | *UnityEngine*.**GradientAlphaKey**                              | ✔               | ✔               | ✖[⁽¹⁾](#note-1)  |
 | Math           | *UnityEngine*.**GradientColorKey**                              | ✔               | ✔               | ✖[⁽¹⁾](#note-1)  |
+| Math           | *UnityEngine*.**Matrix4x4**                                     | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Quaternion**                                    | ✔               | ✔               | ✔                |
-| Math           | *UnityEngine.Rendering*.**SphericalHarmonicsL2**                | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Vector2**                                       | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Vector2Int**                                    | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Vector3**                                       | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Vector3Int**                                    | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Vector4**                                       | ✔               | ✔               | ✔                |
-| Math           | *UnityEngine*.**Matrix4x4**                                     | ✔               | ✔               | ✔                |
+| Math           | *UnityEngine.Rendering*.**SphericalHarmonicsL2**                | ✔               | ✔               | ✔                |
+| Mathematics    | *Unity.Mathematics*.**boolN** [⁽⁸⁾](#note-8)                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
+| Mathematics    | *Unity.Mathematics*.**doubleN** [⁽⁸⁾](#note-8)                  | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
+| Mathematics    | *Unity.Mathematics*.**floatN** [⁽⁸⁾](#note-8)                   | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
+| Mathematics    | *Unity.Mathematics*.**halfN** [⁽⁸⁾](#note-8)                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
+| Mathematics    | *Unity.Mathematics*.**intN** [⁽⁸⁾](#note-8)                     | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
+| Mathematics    | *Unity.Mathematics*.**uintN** [⁽⁸⁾](#note-8)                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
 | NativeArray    | *Unity.Collections*.**NativeArray&lt;T&gt;**                    | ❌[⁽⁴⁾](#note-4) | ✔               | ✔                |
 | NativeArray    | *Unity.Collections*.**NativeSlice&lt;T&gt;**                    | ❌[⁽⁴⁾](#note-4) | ✔               | ✔                |
 | ParticleSystem | *UnityEngine.ParticleSystemJobs*.**ParticleSystemJobData**      | ❌[⁽⁴⁾](#note-4) | ❔[⁽⁵⁾](#note-5) | ❌[⁽⁴⁾](#note-4)  |
@@ -108,21 +114,29 @@ https://beautifuldingbats.com/superscript-generator/
   therefore has been left out. Possible to solve by using reflection tricks
   but this has been down prioritized.
 
-7. ✔<a name="note-7"></a> Support for Addressables package, which was added in
-  v1.4.0, is only automatically included if your Unity project has imported the
-  `com.unity.addressable` package. This automatic inclusion relies on
-  AssemblyDefinition version defines, which was introduced in Unity 2019.1.x.
-  To enable the `AssetReferenceConverter` in earlier versions of Unity, please
-  add `HAVE_MODULE_ADDRESSABLES` to your project's "Scripting Define Symbols"
-  found in the "Project Settings" -> "Player" -> "Other Settings" panel.
+7. ✔<a name="note-7"></a> Support for [Addressables](https://docs.unity3d.com/Packages/com.unity.addressables@2.0/manual/index.html)
+  package, which was added in v1.4.0, is only automatically included if your
+  Unity project has imported the `com.unity.addressable` package.
+  This automatic inclusion relies on AssemblyDefinition version defines,
+  which was introduced in Unity 2019.1.x.
+  To enable the `AssetReferenceConverter` in earlier versions of Unity,
+  please add `HAVE_MODULE_ADDRESSABLES` to your project's
+  "Scripting Define Symbols" found in the
+  "Project Settings" -> "Player" -> "Other Settings" panel.
 
-8. ✔<a name="note-8"></a> Support for Mathematics package, which was added in
-  v1.6.0, is only automatically included if your Unity project has imported the
-  `com.unity.mathematics` package. This automatic inclusion relies on
-  AssemblyDefinition version defines, which was introduced in Unity 2019.1.x.
+8. ✔<a name="note-8"></a> The `N` in for example `floatN` means all the
+  different vector and matrix types available in [Unity.Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/api/Unity.Mathematics.html):
+  `float2`, `float3`, `float4`, `float2x2`, `float2x3`, `float2x4`, etc.
+
+9. ✔<a name="note-9"></a> Support for [Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/manual/index.html)
+  package, which was added in v1.6.0, is only automatically included if your
+  Unity project has imported the `com.unity.mathematics` package.
+  This automatic inclusion relies on AssemblyDefinition version defines,
+  which was introduced in Unity 2019.1.x.
   To enable for example the `Float3Converter` in earlier versions of Unity,
-  please add `HAVE_MODULE_MATHEMATICS` to your project's "Scripting Define Symbols"
-  found in the "Project Settings" -> "Player" -> "Other Settings" panel.
+  please add `HAVE_MODULE_MATHEMATICS` to your project's
+  "Scripting Define Symbols" found in the
+  "Project Settings" -> "Player" -> "Other Settings" panel.
 
 ## Legend
 

--- a/Doc/Compatability-table.md
+++ b/Doc/Compatability-table.md
@@ -43,6 +43,7 @@ https://beautifuldingbats.com/superscript-generator/
 | Math           | *UnityEngine*.**Vector3Int**                                    | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine*.**Vector4**                                       | ✔               | ✔               | ✔                |
 | Math           | *UnityEngine.Rendering*.**SphericalHarmonicsL2**                | ✔               | ✔               | ✔                |
+| Mathematics    | *Unity.Mathematics*.**half**                                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
 | Mathematics    | *Unity.Mathematics*.**boolN** [⁽⁸⁾](#note-8)                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
 | Mathematics    | *Unity.Mathematics*.**doubleN** [⁽⁸⁾](#note-8)                  | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
 | Mathematics    | *Unity.Mathematics*.**floatN** [⁽⁸⁾](#note-8)                   | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |

--- a/Doc/Compatability-table.md
+++ b/Doc/Compatability-table.md
@@ -49,6 +49,11 @@ https://beautifuldingbats.com/superscript-generator/
 | Mathematics    | *Unity.Mathematics*.**halfN** [⁽⁸⁾](#note-8)                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
 | Mathematics    | *Unity.Mathematics*.**intN** [⁽⁸⁾](#note-8)                     | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
 | Mathematics    | *Unity.Mathematics*.**uintN** [⁽⁸⁾](#note-8)                    | ✔[⁽⁹⁾](#note-9) | ✔[⁽⁹⁾](#note-9)  | ✔                |
+| Mathematics    | *Unity.Mathematics*.**boolNxN** [⁽⁸⁾](#note-8)                  | ✔                | ✔              | ✖[⁽¹⁾](#note-1)  |
+| Mathematics    | *Unity.Mathematics*.**doubleNxN** [⁽⁸⁾](#note-8)                | ✔                | ✔              | ✖[⁽¹⁾](#note-1)  |
+| Mathematics    | *Unity.Mathematics*.**floatNxN** [⁽⁸⁾](#note-8)                 | ✔                | ✔              | ✖[⁽¹⁾](#note-1)  |
+| Mathematics    | *Unity.Mathematics*.**intNxN** [⁽⁸⁾](#note-8)                   | ✔                | ✔              | ✖[⁽¹⁾](#note-1)  |
+| Mathematics    | *Unity.Mathematics*.**uintNxN** [⁽⁸⁾](#note-8)                  | ✔                | ✔              | ✖[⁽¹⁾](#note-1)  |
 | NativeArray    | *Unity.Collections*.**NativeArray&lt;T&gt;**                    | ❌[⁽⁴⁾](#note-4) | ✔               | ✔                |
 | NativeArray    | *Unity.Collections*.**NativeSlice&lt;T&gt;**                    | ❌[⁽⁴⁾](#note-4) | ✔               | ✔                |
 | ParticleSystem | *UnityEngine.ParticleSystemJobs*.**ParticleSystemJobData**      | ❌[⁽⁴⁾](#note-4) | ❔[⁽⁵⁾](#note-5) | ❌[⁽⁴⁾](#note-4)  |
@@ -124,9 +129,11 @@ https://beautifuldingbats.com/superscript-generator/
   "Scripting Define Symbols" found in the
   "Project Settings" -> "Player" -> "Other Settings" panel.
 
-8. ✔<a name="note-8"></a> The `N` in for example `floatN` means all the
-  different vector and matrix types available in [Unity.Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/api/Unity.Mathematics.html):
-  `float2`, `float3`, `float4`, `float2x2`, `float2x3`, `float2x4`, etc.
+8. ✔<a name="note-8"></a> The `N` in `floatN`, `intN`, etc. stands for all the
+  different vector types available in [Unity.Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/api/Unity.Mathematics.html):
+  `float2`, `float3`, `float4`, etc.
+  Similarly, the `NxN` in `floatNxN`, `intNxN`, etc. stands for all the
+  different matrix types: `float2x2`, `float2x3`, `float4x4`, etc.
 
 9. ✔<a name="note-9"></a> Support for [Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/manual/index.html)
   package, which was added in v1.6.0, is only automatically included if your

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Newtonsoft.Json.UnityConverters.asmdef
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Newtonsoft.Json.UnityConverters.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Newtonsoft.Json.UnityConverters",
+    "rootNamespace": "Newtonsoft.Json",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -25,6 +26,12 @@
             "name": "com.unity.modules.physics2d",
             "expression": "",
             "define": "HAVE_MODULE_PHYSICS2D"
+        },
+        {
+            "name": "com.unity.mathematics",
+            "expression": "",
+            "define": "HAVE_MODULE_MATHEMATICS"
         }
-    ]
+    ],
+    "noEngineReferences": false
 }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs
@@ -4,6 +4,8 @@ using UnityEngine.Scripting;
 
 [assembly: Preserve]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Addressables")]
+[assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Mathematics")]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Editor")]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Tests")]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Tests.Addressables")]
+[assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Tests.Mathematics")]

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/JsonHelperExtensions.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Helpers/JsonHelperExtensions.cs
@@ -15,7 +15,7 @@ namespace Newtonsoft.Json.UnityConverters.Helpers
         /// <see href="https://github.com/JamesNK/Newtonsoft.Json/blob/12.0.1/Src/Newtonsoft.Json/JsonSerializationException.cs#L110"/>
         /// </summary>
         internal static readonly ConstructorInfo _JsonSerializationExceptionPositionalCtor
-            = typeof(JsonSerializationException).GetConstructor(new [] {
+            = typeof(JsonSerializationException).GetConstructor(new[] {
                 typeof(string), typeof(string), typeof(int), typeof(int), typeof(Exception)
             });
 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04f581c01bcb1174a9340241e0a686a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/BoolConverters.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/BoolConverters.cs
@@ -1,0 +1,100 @@
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Mathematics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="bool2"/> type.
+    /// </summary>
+    public class Bool2Converter : PartialConverter<bool2>
+    {
+        protected override void ReadValue(ref bool2 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsBoolean() ?? false;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsBoolean() ?? false;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, bool2 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="bool3"/> type.
+    /// </summary>
+    public class Bool3Converter : PartialConverter<bool3>
+    {
+        protected override void ReadValue(ref bool3 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsBoolean() ?? false;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsBoolean() ?? false;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsBoolean() ?? false;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, bool3 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="bool4"/> type.
+    /// </summary>
+    public class Bool4Converter : PartialConverter<bool4>
+    {
+        protected override void ReadValue(ref bool4 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsBoolean() ?? false;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsBoolean() ?? false;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsBoolean() ?? false;
+                    break;
+                case nameof(value.w):
+                    value.w = reader.ReadAsBoolean() ?? false;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, bool4 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+            writer.WritePropertyName(nameof(value.w));
+            writer.WriteValue(value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/BoolConverters.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/BoolConverters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7192e0262f9ca74e8e40f149a39f587

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/DoubleConverters.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/DoubleConverters.cs
@@ -1,0 +1,101 @@
+using Newtonsoft.Json.UnityConverters.Helpers;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Mathematics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="double2"/> type.
+    /// </summary>
+    public class Double2Converter : PartialConverter<double2>
+    {
+        protected override void ReadValue(ref double2 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsDouble() ?? 0f;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsDouble() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, double2 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="double3"/> type.
+    /// </summary>
+    public class Double3Converter : PartialConverter<double3>
+    {
+        protected override void ReadValue(ref double3 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsDouble() ?? 0f;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsDouble() ?? 0f;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsDouble() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, double3 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="double4"/> type.
+    /// </summary>
+    public class Double4Converter : PartialConverter<double4>
+    {
+        protected override void ReadValue(ref double4 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsDouble() ?? 0f;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsDouble() ?? 0f;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsDouble() ?? 0f;
+                    break;
+                case nameof(value.w):
+                    value.w = reader.ReadAsDouble() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, double4 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+            writer.WritePropertyName(nameof(value.w));
+            writer.WriteValue(value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/DoubleConverters.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/DoubleConverters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3cb272eb5ac884d45bc34c327bc74149

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/FloatConverters.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/FloatConverters.cs
@@ -1,0 +1,101 @@
+using Newtonsoft.Json.UnityConverters.Helpers;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Mathematics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="float2"/> type.
+    /// </summary>
+    public class Float2Converter : PartialConverter<float2>
+    {
+        protected override void ReadValue(ref float2 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsFloat() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, float2 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="float3"/> type.
+    /// </summary>
+    public class Float3Converter : PartialConverter<float3>
+    {
+        protected override void ReadValue(ref float3 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsFloat() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, float3 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="float4"/> type.
+    /// </summary>
+    public class Float4Converter : PartialConverter<float4>
+    {
+        protected override void ReadValue(ref float4 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.w):
+                    value.w = reader.ReadAsFloat() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, float4 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+            writer.WritePropertyName(nameof(value.w));
+            writer.WriteValue(value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/FloatConverters.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/FloatConverters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52c3c92eef2cc7b4f9cacdd50e3254ed

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/HalfConverters.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/HalfConverters.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Globalization;
+using Newtonsoft.Json.UnityConverters.Helpers;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Mathematics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="half"/> type.
+    /// </summary>
+    public class HalfConverter : JsonConverter<half>
+    {
+        public override half ReadJson(JsonReader reader, Type objectType, half existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return new half((double)reader.Value);
+        }
+
+        public override void WriteJson(JsonWriter writer, half value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="half2"/> type.
+    /// </summary>
+    public class Half2Converter : PartialConverter<half2>
+    {
+        protected override void ReadValue(ref half2 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+                case nameof(value.y):
+                    value.y = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, half2 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="half3"/> type.
+    /// </summary>
+    public class Half3Converter : PartialConverter<half3>
+    {
+        protected override void ReadValue(ref half3 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+                case nameof(value.y):
+                    value.y = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+                case nameof(value.z):
+                    value.z = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, half3 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="half4"/> type.
+    /// </summary>
+    public class Half4Converter : PartialConverter<half4>
+    {
+        protected override void ReadValue(ref half4 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+                case nameof(value.y):
+                    value.y = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+                case nameof(value.z):
+                    value.z = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+                case nameof(value.w):
+                    value.w = new half(reader.ReadAsFloat() ?? 0f);
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, half4 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+            writer.WritePropertyName(nameof(value.w));
+            writer.WriteValue(value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/HalfConverters.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/HalfConverters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7e4310aa6869224087dea132503d3fc

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/IntConverters.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/IntConverters.cs
@@ -1,0 +1,100 @@
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Mathematics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="int2"/> type.
+    /// </summary>
+    public class Int2Converter : PartialConverter<int2>
+    {
+        protected override void ReadValue(ref int2 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsInt32() ?? 0;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, int2 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="int3"/> type.
+    /// </summary>
+    public class Int3Converter : PartialConverter<int3>
+    {
+        protected override void ReadValue(ref int3 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsInt32() ?? 0;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, int3 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="int4"/> type.
+    /// </summary>
+    public class Int4Converter : PartialConverter<int4>
+    {
+        protected override void ReadValue(ref int4 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.y):
+                    value.y = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.z):
+                    value.z = reader.ReadAsInt32() ?? 0;
+                    break;
+                case nameof(value.w):
+                    value.w = reader.ReadAsInt32() ?? 0;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, int4 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+            writer.WritePropertyName(nameof(value.w));
+            writer.WriteValue(value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/IntConverters.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/IntConverters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 21157b5ca789ab142bee411e5de87f82

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/Newtonsoft.Json.UnityConverters.Mathematics.asmdef
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/Newtonsoft.Json.UnityConverters.Mathematics.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "Newtonsoft.Json.UnityConverters.Mathematics",
+    "rootNamespace": "",
+    "references": [
+        "Unity.Mathematics",
+        "Newtonsoft.Json.UnityConverters"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "HAVE_MODULE_MATHEMATICS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.mathematics",
+            "expression": "",
+            "define": "HAVE_MODULE_MATHEMATICS"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/Newtonsoft.Json.UnityConverters.Mathematics.asmdef
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/Newtonsoft.Json.UnityConverters.Mathematics.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "Newtonsoft.Json.UnityConverters.Mathematics",
-    "rootNamespace": "",
     "references": [
         "Unity.Mathematics",
         "Newtonsoft.Json.UnityConverters"

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/Newtonsoft.Json.UnityConverters.Mathematics.asmdef.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/Newtonsoft.Json.UnityConverters.Mathematics.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 40c175c2a7668e94380e475f4008bdfe
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/QuaternionConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/QuaternionConverter.cs
@@ -1,0 +1,66 @@
+﻿#region License
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Wanzyee Studio
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#endregion
+
+using Newtonsoft.Json.UnityConverters.Helpers;
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Math
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics type <see cref="quaternion"/>.
+    /// </summary>
+    public class QuaternionConverter : PartialConverter<quaternion>
+    {
+        protected override void ReadValue(ref quaternion value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.value.x):
+                    value.value.x = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.value.y):
+                    value.value.y = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.value.z):
+                    value.value.z = reader.ReadAsFloat() ?? 0f;
+                    break;
+                case nameof(value.value.w):
+                    value.value.w = reader.ReadAsFloat() ?? 0f;
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, quaternion value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.value.x));
+            writer.WriteValue(value.value.x);
+            writer.WritePropertyName(nameof(value.value.y));
+            writer.WriteValue(value.value.y);
+            writer.WritePropertyName(nameof(value.value.z));
+            writer.WriteValue(value.value.z);
+            writer.WritePropertyName(nameof(value.value.w));
+            writer.WriteValue(value.value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/QuaternionConverter.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/QuaternionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0662c3c2f1325ec40b471a5425bc15ae

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/UintConverters.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/UintConverters.cs
@@ -1,0 +1,100 @@
+using Unity.Mathematics;
+
+namespace Newtonsoft.Json.UnityConverters.Mathematics
+{
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="uint2"/> type.
+    /// </summary>
+    public class Uint2Converter : PartialConverter<uint2>
+    {
+        protected override void ReadValue(ref uint2 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+                case nameof(value.y):
+                    value.y = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, uint2 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="uint3"/> type.
+    /// </summary>
+    public class Uint3Converter : PartialConverter<uint3>
+    {
+        protected override void ReadValue(ref uint3 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+                case nameof(value.y):
+                    value.y = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+                case nameof(value.z):
+                    value.z = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, uint3 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+        }
+    }
+
+    /// <summary>
+    /// Custom Newtonsoft.Json converter <see cref="JsonConverter"/> for the Unity.Mathematics <see cref="uint4"/> type.
+    /// </summary>
+    public class Uint4Converter : PartialConverter<uint4>
+    {
+        protected override void ReadValue(ref uint4 value, string name, JsonReader reader, JsonSerializer serializer)
+        {
+            switch (name)
+            {
+                case nameof(value.x):
+                    value.x = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+                case nameof(value.y):
+                    value.y = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+                case nameof(value.z):
+                    value.z = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+                case nameof(value.w):
+                    value.w = (uint)(reader.ReadAsInt32() ?? 0);
+                    break;
+            }
+        }
+
+        protected override void WriteJsonProperties(JsonWriter writer, uint4 value, JsonSerializer serializer)
+        {
+            writer.WritePropertyName(nameof(value.x));
+            writer.WriteValue(value.x);
+            writer.WritePropertyName(nameof(value.y));
+            writer.WriteValue(value.y);
+            writer.WritePropertyName(nameof(value.z));
+            writer.WriteValue(value.z);
+            writer.WritePropertyName(nameof(value.w));
+            writer.WriteValue(value.w);
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/UintConverters.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Mathematics/UintConverters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba23a0ca26ac57845bb4ab5e61fe50c1


### PR DESCRIPTION
Added new asmdef that's automatically enabled when com.unity.mathematics is installed, that contains converters for all the Unity.Mathematics types.

Vanilla Json.NET is able to convert the matrix types (e.g `float3x4`) out-of-the-box, as they don't have tons of recursive helper properties.

I tried generalizing it in a way of different approaches, but then ended up with "copy pasting is just better here". Generalizing this would require some quite over-engineered types, that would probably loose tons in performance.