### PR TITLE
Fix wrong namespace in `Unity.Mathematics.quaternion`

### DIFF
--- a/Packages/manifest_2020.1.0b6.json
+++ b/Packages/manifest_2020.1.0b6.json
@@ -15,7 +15,7 @@
     "com.unity.ext.nunit": "1.0.0",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.0",
-    "com.unity.ide.vscode": "1.2.0",
+    "com.unity.mathematics": "1.2.6",
     "com.unity.test-framework": "1.1.13",
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",


### PR DESCRIPTION
Fixes #86 