### PR TITLE
Release 1.6.2

### DIFF
--- a/Build/version.json
+++ b/Build/version.json
@@ -3,5 +3,5 @@
   "Minor": 6,
   "Patch": 2,
   "Suffix": "",
-  "AutoDeployLiveRun": false
+  "AutoDeployLiveRun": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unity Converters for Newtonsoft.Json changelog
 
-## 1.6.2 (WIP)
+## 1.6.2 (2024-01-08)
 
 - Fixed typo in the new Unity.Mathematics QuaternionConverter's namespace:
   from `Newtonsoft.Json.UnityConverters.Math.QuaternionConverter`


### PR DESCRIPTION
## Changes

- Fixed typo in the new Unity.Mathematics QuaternionConverter's namespace: from `Newtonsoft.Json.UnityConverters.Math.QuaternionConverter` to `Newtonsoft.Json.UnityConverters.Mathematics.QuaternionConverter` (`Math` &rarr; `Mathematics`). ([#87](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/87))

- Fixed compilation error when using Unity.Mathematics with Newtonsoft.JSON v10. ([#87](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/87))