### PR TITLE
Fix resolving JSON converters with colliding type names in different assemblies

### DIFF
--- a/Assets/Resources/Newtonsoft.Json-for-Unity.Converters.asset
+++ b/Assets/Resources/Newtonsoft.Json-for-Unity.Converters.asset
@@ -19,142 +19,188 @@ MonoBehaviour:
   unityConverters:
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Addressables.AssetReferenceConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters.Addressables
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.AI.NavMesh.NavMeshQueryFilterConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.AI.NavMesh.NavMeshTriangulationConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Camera.CullingGroupEventConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.BoundsConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.BoundsIntConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.PlaneConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.RectConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.RectIntConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Geometry.RectOffsetConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Graphics.ResolutionConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Hashing.Hash128Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Color32Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.ColorConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Matrix4x4Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.QuaternionConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.SphericalHarmonicsL2Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Vector2Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Vector2IntConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Vector3Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Vector3IntConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Math.Vector4Converter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.NativeArray.NativeArrayConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Physics.JointDriveConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Physics.JointLimitsConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Physics.SoftJointLimitConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Physics2D.ColliderDistance2DConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Physics2D.ContactFilter2DConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Random.RandomStateConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Scripting.LayerMaskConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.UnityConverters.Scripting.RangeIntConverter
+    converterAssembly: Newtonsoft.Json.UnityConverters
     settings: []
   useAllJsonNetConverters: 0
   jsonNetConverters:
   - enabled: 1
     converterName: Newtonsoft.Json.Converters.StringEnumConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 1
     converterName: Newtonsoft.Json.Converters.VersionConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.BinaryConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.BsonObjectIdConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.DataSetConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.DataTableConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.DiscriminatedUnionConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.EntityKeyMemberConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.ExpandoObjectConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.IsoDateTimeConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.JavaScriptDateTimeConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.KeyValuePairConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.RegexConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.UnixDateTimeConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   - enabled: 0
     converterName: Newtonsoft.Json.Converters.XmlNodeConverter
+    converterAssembly: Newtonsoft.Json
     settings: []
   autoSyncConverters: 1

--- a/Build/version.json
+++ b/Build/version.json
@@ -1,7 +1,7 @@
 {
   "Major": 1,
   "Minor": 6,
-  "Patch": 2,
+  "Patch": 3,
   "Suffix": "",
-  "AutoDeployLiveRun": true
+  "AutoDeployLiveRun": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Unity Converters for Newtonsoft.Json changelog
 
+## 1.6.3 (WIP)
+
+- Fixed converter lookups collisions when multiple assemblies converters
+  with the same name, as it was not resolving assemblies in an exact way
+  nor deterministic order:
+
+  - Added assembly name field to `ConverterConfig` for each converter.
+
+  - Changed TypeCache to sort assemblies based on `FullName`
+    and some heuristics.
+
+  - Changed TypeCache to lookup type in correct assembly,
+    based on the assembly's name.
+
+  Thanks [@Erifirin](https://github.com/Erifirin) for the pull request ([#90](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/90))
+
 ## 1.6.2 (2024-01-08)
 
 - Fixed typo in the new Unity.Mathematics QuaternionConverter's namespace:

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/ConverterConfig.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/ConverterConfig.cs
@@ -12,11 +12,13 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
 
         public string converterName;
 
+        public string converterAssembly;
+
         public List<KeyedConfig> settings;
 
         public override string ToString()
         {
-            return $"{{enabled={enabled}, converterName={converterName}, settings=[{settings?.Count ?? 0}]}}";
+            return $"{{enabled={enabled}, converterName={converterName}, assembly={converterAssembly}, settings=[{settings?.Count ?? 0}]}}";
         }
 
         public override bool Equals(object obj)
@@ -28,6 +30,7 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
         {
             return enabled == other.enabled &&
                    converterName == other.converterName &&
+                   converterAssembly == other.converterAssembly &&
                    EqualityComparer<List<KeyedConfig>>.Default.Equals(settings, other.settings);
         }
 
@@ -35,9 +38,10 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
         public override int GetHashCode()
 #pragma warning restore S2328 // "GetHashCode" should not reference mutable fields
         {
-            int hashCode = 1016066258;
+            int hashCode = 913629501;
             hashCode = hashCode * -1521134295 + enabled.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(converterName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(converterAssembly);
             hashCode = hashCode * -1521134295 + EqualityComparer<List<KeyedConfig>>.Default.GetHashCode(settings);
             return hashCode;
         }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -157,15 +157,15 @@ namespace Newtonsoft.Json.UnityConverters
             }
 
             return new ConverterGrouping {
-                outsideConverters = config.outsideConverters.Select(x => GetTypeOrLog(x.converterName)).WhereNotNullRef().ToList(),
-                unityConverters = config.unityConverters.Select(x => GetTypeOrLog(x.converterName)).WhereNotNullRef().ToList(),
-                jsonNetConverters = config.jsonNetConverters.Select(x => GetTypeOrLog(x.converterName)).WhereNotNullRef().ToList(),
+                outsideConverters = config.outsideConverters.Select(x => GetTypeOrLog(x.converterName, x.converterAssembly)).WhereNotNullRef().ToList(),
+                unityConverters = config.unityConverters.Select(x => GetTypeOrLog(x.converterName, x.converterAssembly)).WhereNotNullRef().ToList(),
+                jsonNetConverters = config.jsonNetConverters.Select(x => GetTypeOrLog(x.converterName, x.converterAssembly)).WhereNotNullRef().ToList(),
             };
         }
 
-        private static Type GetTypeOrLog(string name)
+        private static Type GetTypeOrLog(string name, string assemblyName)
         {
-            var type = TypeCache.FindType(name);
+            var type = TypeCache.FindType(name, assemblyName);
             if (type == null)
             {
                 Debug.LogWarning($"Failed to lookup JsonConverter type. Ignoring it. Type name: \"{name}\""+
@@ -215,7 +215,7 @@ namespace Newtonsoft.Json.UnityConverters
 
             var typesOfEnabledThroughConfig = configs
                 .Where(o => o.enabled)
-                .Select(o => Utility.TypeCache.FindType(o.converterName))
+                .Select(o => Utility.TypeCache.FindType(o.converterName, o.converterAssembly))
                 .Where(o => o != null);
 
             var hashMap = new HashSet<Type>(typesOfEnabledThroughConfig);

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
@@ -16,7 +16,15 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                 // When searching for types we want to look in mscorlib last
                 // and Newtonsoft.Json up as the first ones
                 .Reverse()
+                .OrderBy(Order)
                 .ToArray();
+
+        private static int Order(Assembly assembly)
+        {
+            if (assembly.FullName.StartsWith("Newtonsoft.Json")) return -1;
+            if (assembly.FullName == "mscorlib") return 1;
+            return 0;
+        }
 
         public static Type FindType(string name)
         {

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
@@ -7,8 +7,6 @@ namespace Newtonsoft.Json.UnityConverters.Utility
 {
     internal static class TypeCache
     {
-        private static readonly Dictionary<string, Type> _typeByName
-            = new Dictionary<string, Type>();
         private static readonly Dictionary<ValueTuple<string, string>, Type> _typeByNameAndAssembly
             = new Dictionary<ValueTuple<string, string>, Type>();
         private static readonly Dictionary<string, Assembly> _assemblyByName
@@ -88,11 +86,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
 
         public static Type FindType(string name, string assemblyName)
         {
-            if (_typeByName.TryGetValue(name, out var type))
-            {
-                return type;
-            }
-
+            Type type;
             if (assemblyName != null)
             {
                 if (_typeByNameAndAssembly.TryGetValue((name, assemblyName), out type))
@@ -105,10 +99,16 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                     type = asm.GetType(name);
                     if (type != null)
                     {
-                        _typeByName[name] = type;
                         _typeByNameAndAssembly[(name, assemblyName)] = type;
                         return type;
                     }
+                }
+            }
+            else
+            {
+                if (_typeByNameAndAssembly.TryGetValue((name, null), out type))
+                {
+                    return type;
                 }
             }
 
@@ -116,8 +116,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
             type = Type.GetType(name);
             if (type != null)
             {
-                _typeByName[name] = type;
-                _typeByNameAndAssembly[(name, type.Assembly.GetName().Name)] = type;
+                _typeByNameAndAssembly[(name, null)] = type;
                 return type;
             }
 
@@ -127,8 +126,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                 type = assembly.GetType(name);
                 if (type != null)
                 {
-                    _typeByName[name] = type;
-                    _typeByNameAndAssembly[(name, type.Assembly.GetName().Name)] = type;
+                    _typeByNameAndAssembly[(name, null)] = type;
                     return type;
                 }
             }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
@@ -22,7 +22,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
         private static int Order(Assembly assembly)
         {
             if (assembly.FullName.StartsWith("Newtonsoft.Json")) return -1;
-            if (assembly.FullName == "mscorlib") return 1;
+            if (assembly.FullName.StartsWith("mscorlib")) return 1;
             return 0;
         }
 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
@@ -23,7 +23,6 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                 .OrderBy(AssemblyOrderBy).ThenBy(x => x.FullName)
                 .ToArray();
 
-            UnityEngine.Debug.Log("Assemblies:\n"+string.Join("\n", _assemblies.Select(x => x.FullName)));
             _assemblyByName = new Dictionary<string, Assembly>();
             foreach (var assembly in _assemblies)
             {
@@ -42,6 +41,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                 return -10;
             }
 
+            // Relies on the heuristic that "assembly name == namespace"
             switch (GetRootNamespace(name))
             {
                 // User-defined code gets sent to the top
@@ -101,6 +101,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                     type = asm.GetType(name);
                     if (type != null)
                     {
+                        _typeByName[name] = type;
                         _typeByNameAndAssembly[(name, assemblyName)] = type;
                         return type;
                     }
@@ -112,6 +113,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
             if (type != null)
             {
                 _typeByName[name] = type;
+                _typeByNameAndAssembly[(name, type.Assembly.GetName().Name)] = type;
                 return type;
             }
 
@@ -122,6 +124,7 @@ namespace Newtonsoft.Json.UnityConverters.Utility
                 if (type != null)
                 {
                     _typeByName[name] = type;
+                    _typeByNameAndAssembly[(name, type.Assembly.GetName().Name)] = type;
                     return type;
                 }
             }


### PR DESCRIPTION
Based on @Erifirin's work in #90

- Changed TypeCache to lookup assemblies in deterministic order
- Added field `converterAssembly` to `ConverterConfig`, so it keeps track of which assembly it belongs to.
- Changed TypeCache to lookup type in specific assembly, if any is given, but fallback to still looking up in any assembly.

