### PR TITLE
Release 1.6.3

### DIFF
--- a/Build/version.json
+++ b/Build/version.json
@@ -3,5 +3,5 @@
   "Minor": 6,
   "Patch": 3,
   "Suffix": "",
-  "AutoDeployLiveRun": false
+  "AutoDeployLiveRun": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unity Converters for Newtonsoft.Json changelog
 
-## 1.6.3 (WIP)
+## 1.6.3 (2024-03-01)
 
 - Fixed converter lookups collisions when multiple assemblies converters
   with the same name, as it was not resolving assemblies in an exact way


### PR DESCRIPTION
## Changelog

- Fixed converter lookups collisions when multiple assemblies converters with the same name, as it was not resolving assemblies in an exact way nor deterministic order:

  - Added assembly name field to `ConverterConfig` for each converter.

  - Changed TypeCache to sort assemblies based on `FullName` and some heuristics.

  - Changed TypeCache to lookup type in correct assembly, based on the assembly's name.

  Thanks [@Erifirin](https://github.com/Erifirin) for the pull request ([#90](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/90))
